### PR TITLE
model(llava): size the projector buffer by images, not images x channels

### DIFF
--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -386,7 +386,13 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
             image_features = projected_features[:, :num_real_patches, :]
         else:
             projector_out_size = [
-                pixel_values.shape[0] * pixel_values.shape[1],
+                # Images, not images x channels: this pixel_values is
+                # (num_images, 3, H, W), so dim 1 is the channel count. Multiplying
+                # by it (the LLaVA-NeXT shape, where dim 1 is num_patches) sized the
+                # buffer 3x too large, and get_image_features returned three images'
+                # worth of features for one image. vision_out_size above already
+                # uses shape[0] alone.
+                pixel_values.shape[0],
                 (self.config.vision_config.image_size // self.config.vision_config.patch_size) ** 2,
                 self.config.text_config.hidden_size,
             ]

--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -386,12 +386,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
             image_features = projected_features[:, :num_real_patches, :]
         else:
             projector_out_size = [
-                # Images, not images x channels: this pixel_values is
-                # (num_images, 3, H, W), so dim 1 is the channel count. Multiplying
-                # by it (the LLaVA-NeXT shape, where dim 1 is num_patches) sized the
-                # buffer 3x too large, and get_image_features returned three images'
-                # worth of features for one image. vision_out_size above already
-                # uses shape[0] alone.
+                # pixel_values is (num_images, channels, height, width).
                 pixel_values.shape[0],
                 (self.config.vision_config.image_size // self.config.vision_config.patch_size) ** 2,
                 self.config.text_config.hidden_size,


### PR DESCRIPTION
## Symptom

Serving `llava-hf/llava-1.5-7b-hf` with one image fails at the first request:

```
ValueError: Multimodal placeholder/embedding count mismatch:
576 placeholder positions but 1728 embed tokens
```

576 = (336 / 14)² is the correct count for one LLaVA-1.5 image, and the model's own config agrees (`image_seq_length: 576`, `vision_config.image_size: 336`, `patch_size: 14`). 1728 is exactly **3×** that.

## Cause

`RBLNLlavaForConditionalGeneration.get_image_features` pre-allocates the projector output as

```python
projector_out_size = [
    pixel_values.shape[0] * pixel_values.shape[1],
    (image_size // patch_size) ** 2,
    text_hidden_size,
]
```

For LLaVA-1.5 `pixel_values` is `(num_images, 3, H, W)`, so **dim 1 is the channel count**. With one image the leading dimension becomes `1 × 3 = 3`, the buffer is three times too large, and the call returns three images' worth of features — which is where the 3× comes from.

Two things confirm the reading:

- **`vision_out_size`, a few lines above in the same function, uses `pixel_values.shape[0]` alone.** The two buffers disagreed about what dim 1 means.
- **The expression is the LLaVA-NeXT shape.** There `pixel_values` is `(batch, num_patches, 3, H, W)` — `modeling_llava_next.py` branches explicitly on `pixel_values.dim() == 5` — so `shape[0] * shape[1]` is right, and LLaVA-NeXT serves correctly. It looks carried over into the 4-D path.

## Fix

Use `pixel_values.shape[0]`, matching `vision_out_size` in the same function. One line, plus a comment recording why dim 1 must not be multiplied in here.

## Verification

Reproduced end to end by serving the documented recipe command on RBLN-CA22 (16 devices, KMD 3.2.2) with `vllm 0.22.0+cpu` + `vllm-rbln 0.11.1`:

```
VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK=4 \
vllm serve llava-hf/llava-1.5-7b-hf \
    --served-model-name llava-1.5-7b-hf \
    --max-model-len 4096 --block-size 4096 --max-num-seqs 1
```

The mismatch is deterministic on the first request. `llava-next-mistral-7b`, `qwen2-vl-7b`, `idefics3-8b` and `qwen2.5-vl-7b` all served images fine in the same sweep, which is what isolated this to the 4-D LLaVA path rather than multimodal serving in general.

**No test:** the function needs a compiled RBLN vision tower, so there is no unit seam for the shape arithmetic in the current test layout (`tests/test_transformers.py` instantiates and compiles). Happy to add one if you would like a mocked vision tower for this.

## Provenance

Found while running all 53 documented vLLM recipes from `rbln_sdk_doc` on hardware, verbatim as a reader would copy them.