### PR TITLE
model: propagate top-level batch_size to VLM language-model submodules

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -543,6 +543,10 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             return submodule_config
 
         if isinstance(submodule_config, dict):
+            # A None-valued kwarg means the parent left it unset: it neither propagates to the
+            # submodule nor participates in the force_kwargs conflict check.
+            kwargs = {key: value for key, value in kwargs.items() if value is not None}
+
             from_predecessor = self._runtime_options.copy()
             from_predecessor.update(
                 {

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -543,10 +543,6 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             return submodule_config
 
         if isinstance(submodule_config, dict):
-            # A None-valued kwarg means the parent left it unset: it neither propagates to the
-            # submodule nor participates in the force_kwargs conflict check.
-            kwargs = {key: value for key, value in kwargs.items() if value is not None}
-
             from_predecessor = self._runtime_options.copy()
             from_predecessor.update(
                 {

--- a/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
@@ -117,4 +117,6 @@ class RBLNBlip2ForConditionalGenerationConfig(RBLNModelConfig):
             submodule_config=vision_model, batch_size=1, force_kwargs=True
         )
         self.qformer = self.initialize_submodule_config(submodule_config=qformer, batch_size=1, force_kwargs=True)
-        self.language_model = self.initialize_submodule_config(submodule_config=language_model)
+        self.language_model = self.initialize_submodule_config(
+            submodule_config=language_model, batch_size=batch_size, force_kwargs=True
+        )

--- a/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
@@ -117,6 +117,4 @@ class RBLNBlip2ForConditionalGenerationConfig(RBLNModelConfig):
             submodule_config=vision_model, batch_size=1, force_kwargs=True
         )
         self.qformer = self.initialize_submodule_config(submodule_config=qformer, batch_size=1, force_kwargs=True)
-        self.language_model = self.initialize_submodule_config(
-            submodule_config=language_model, batch_size=batch_size, force_kwargs=True
-        )
+        self.language_model = self.initialize_submodule_config(submodule_config=language_model, batch_size=batch_size)

--- a/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
+++ b/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
@@ -83,7 +83,6 @@ class RBLNColQwen2ForRetrievalConfig(RBLNDecoderOnlyModelConfig):
             submodule_config=vlm,
             batch_size=batch_size,
             output_hidden_states=output_hidden_states,
-            force_kwargs=True,
             logits_to_keep=0,
             use_inputs_embeds=True,
         )

--- a/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
@@ -93,7 +93,9 @@ class RBLNGemma3ForConditionalGenerationConfig(RBLNModelConfig):
         self.vision_tower = self.initialize_submodule_config(
             submodule_config=vision_tower, batch_size=1, force_kwargs=True
         )
-        self.language_model = self.initialize_submodule_config(submodule_config=language_model)
+        self.language_model = self.initialize_submodule_config(
+            submodule_config=language_model, batch_size=batch_size, force_kwargs=True
+        )
 
     @property
     def image_prefill_chunk_size(self):

--- a/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
@@ -93,9 +93,7 @@ class RBLNGemma3ForConditionalGenerationConfig(RBLNModelConfig):
         self.vision_tower = self.initialize_submodule_config(
             submodule_config=vision_tower, batch_size=1, force_kwargs=True
         )
-        self.language_model = self.initialize_submodule_config(
-            submodule_config=language_model, batch_size=batch_size, force_kwargs=True
-        )
+        self.language_model = self.initialize_submodule_config(submodule_config=language_model, batch_size=batch_size)
 
     @property
     def image_prefill_chunk_size(self):

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -216,6 +216,7 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
         )
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
+            batch_size=batch_size,
             force_kwargs=True,
             use_inputs_embeds=True,
         )

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -217,7 +217,6 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
             batch_size=batch_size,
-            force_kwargs=True,
             use_inputs_embeds=True,
         )
 

--- a/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
@@ -86,6 +86,4 @@ class RBLNIdefics3ForConditionalGenerationConfig(RBLNModelConfig):
         self.vision_model = self.initialize_submodule_config(
             submodule_config=vision_model, batch_size=1, force_kwargs=True
         )
-        self.text_model = self.initialize_submodule_config(
-            submodule_config=text_model, batch_size=batch_size, force_kwargs=True
-        )
+        self.text_model = self.initialize_submodule_config(submodule_config=text_model, batch_size=batch_size)

--- a/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
@@ -86,4 +86,6 @@ class RBLNIdefics3ForConditionalGenerationConfig(RBLNModelConfig):
         self.vision_model = self.initialize_submodule_config(
             submodule_config=vision_model, batch_size=1, force_kwargs=True
         )
-        self.text_model = self.initialize_submodule_config(submodule_config=text_model)
+        self.text_model = self.initialize_submodule_config(
+            submodule_config=text_model, batch_size=batch_size, force_kwargs=True
+        )

--- a/src/optimum/rbln/transformers/models/llava/configuration_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/configuration_llava.py
@@ -71,5 +71,4 @@ class RBLNLlavaForConditionalGenerationConfig(RBLNModelConfig):
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
             batch_size=batch_size,
-            force_kwargs=True,
         )

--- a/src/optimum/rbln/transformers/models/llava/configuration_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/configuration_llava.py
@@ -70,4 +70,6 @@ class RBLNLlavaForConditionalGenerationConfig(RBLNModelConfig):
 
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
+            batch_size=batch_size,
+            force_kwargs=True,
         )

--- a/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
@@ -66,4 +66,6 @@ class RBLNLlavaNextForConditionalGenerationConfig(RBLNModelConfig):
 
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
+            batch_size=batch_size,
+            force_kwargs=True,
         )

--- a/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
@@ -67,5 +67,4 @@ class RBLNLlavaNextForConditionalGenerationConfig(RBLNModelConfig):
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
             batch_size=batch_size,
-            force_kwargs=True,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -266,9 +266,9 @@ def _submodule_batch_size(sub):
     ],
 )
 def test_composite_vlm_batch_size_propagation(config_cls_name, lm_key):
-    """Regression: a top-level `batch_size` must reach the language-model submodule, a
-    submodule-only `batch_size` must not conflict with the parent's unset (None) value,
-    and setting both to different values must raise."""
+    """Regression: a top-level `batch_size` must reach the language-model submodule as a
+    soft default — a submodule-only `batch_size` must not conflict with the parent's unset
+    (None) value, and when both are set the submodule wins."""
     import optimum.rbln
 
     config_cls = getattr(optimum.rbln, config_cls_name)
@@ -279,8 +279,8 @@ def test_composite_vlm_batch_size_propagation(config_cls_name, lm_key):
     cfg = config_cls(**{lm_key: {"batch_size": 4}})
     assert _submodule_batch_size(getattr(cfg, lm_key)) == 4
 
-    with pytest.raises(ValueError, match="Parameter conflict for 'batch_size'"):
-        config_cls(batch_size=1, **{lm_key: {"batch_size": 4}})
+    cfg = config_cls(batch_size=1, **{lm_key: {"batch_size": 4}})
+    assert _submodule_batch_size(getattr(cfg, lm_key)) == 4
 
     cfg = config_cls(batch_size=4, **{lm_key: {"batch_size": 4}})
     assert _submodule_batch_size(getattr(cfg, lm_key)) == 4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -250,6 +250,50 @@ def test_submodule_config_dict_deprecated_tensor_parallel_size():
     assert sub_inherit.num_devices == 2
 
 
+def _submodule_batch_size(sub):
+    return sub["batch_size"] if isinstance(sub, dict) else sub.batch_size
+
+
+@pytest.mark.parametrize(
+    "config_cls_name, lm_key",
+    [
+        ("RBLNGemma3ForConditionalGenerationConfig", "language_model"),
+        ("RBLNGemma4ForConditionalGenerationConfig", "language_model"),
+        ("RBLNLlavaForConditionalGenerationConfig", "language_model"),
+        ("RBLNLlavaNextForConditionalGenerationConfig", "language_model"),
+        ("RBLNBlip2ForConditionalGenerationConfig", "language_model"),
+        ("RBLNIdefics3ForConditionalGenerationConfig", "text_model"),
+    ],
+)
+def test_composite_vlm_batch_size_propagation(config_cls_name, lm_key):
+    """Regression: a top-level `batch_size` must reach the language-model submodule, a
+    submodule-only `batch_size` must not conflict with the parent's unset (None) value,
+    and setting both to different values must raise."""
+    import optimum.rbln
+
+    config_cls = getattr(optimum.rbln, config_cls_name)
+
+    cfg = config_cls(batch_size=2)
+    assert _submodule_batch_size(getattr(cfg, lm_key)) == 2
+
+    cfg = config_cls(**{lm_key: {"batch_size": 4}})
+    assert _submodule_batch_size(getattr(cfg, lm_key)) == 4
+
+    with pytest.raises(ValueError, match="Parameter conflict for 'batch_size'"):
+        config_cls(batch_size=1, **{lm_key: {"batch_size": 4}})
+
+    cfg = config_cls(batch_size=4, **{lm_key: {"batch_size": 4}})
+    assert _submodule_batch_size(getattr(cfg, lm_key)) == 4
+
+
+def test_colqwen2_submodule_only_kwargs_no_conflict():
+    """Regression: `vlm`-only settings must not conflict with the parent's unset (None) kwargs."""
+    import optimum.rbln
+
+    cfg = optimum.rbln.RBLNColQwen2ForRetrievalConfig(vlm={"batch_size": 4, "output_hidden_states": True})
+    assert _submodule_batch_size(cfg.vlm) == 4
+
+
 @pytest.mark.parametrize(
     "invalid_param",
     [


### PR DESCRIPTION
Follow-up to #650. That PR fixed the vllm-rbln case (`{"language_model": {"batch_size": N}}`, no top-level key) by dropping the `batch_size` kwarg from gemma4's `initialize_submodule_config` call — but that also removed the only path by which a **top-level** `batch_size` reached the language model, so `rbln_config={"batch_size": 2}` silently compiled the LM at batch 1. gemma3 / llava / llava_next / blip_2 / idefics3 had the same gap all along (their parent docstrings say "The batch size for inference", but the value never left the parent config).

## Fix

Propagate the top-level `batch_size` to the language-model submodule as a **soft default**, the way paligemma already does: pass `batch_size=batch_size` **without** `force_kwargs`. In `initialize_submodule_config` the submodule dict is applied on top of the parent's kwargs, so:

- top-level only → propagates to the language model
- submodule only → submodule value used (vllm-rbln style, the #650 case — unchanged)
- both set → submodule wins (dev behavior, unchanged)

The parent→submodule kwargs machinery in `initialize_submodule_config` exists to propagate infra settings — `num_devices` (TP), `npu`, and the runtime options — down to submodules; `force_kwargs` came in with it (#267) for literal vision pins (`batch_size=1`). Reusing it to force the parent's *resolved* `batch_size` onto the language model overloaded that mechanism and turned a default into a hard requirement — which is why #650 was needed in the first place. `force_kwargs` remains only where a literal pin is intended (vision towers at `batch_size=1`).

Applied to gemma4 (restores the propagation removed in #650, without the conflict), gemma3, llava, llava_next, blip_2, and idefics3 (`text_model`). The qwen-family VLMs need nothing — their parent config *is* the CausalLM config.

**colqwen2** had a live instance of the same wrong `force_kwargs` usage: it forces `batch_size` / `output_hidden_states` that may be `None`, so `vlm={"batch_size": 4}` alone raised `Parameter conflict: 4 != None`. Dropping `force_kwargs` from its `vlm` call fixes it the same way.

## Before / after

Idefics3 (`trl-internal-testing/tiny-Idefics3ForConditionalGeneration`), verified by compiling on this branch vs `dev` (2a13f24f):

**model_0** — `rbln_config={"batch_size": 2, "text_model": {"max_seq_len": 2048}}`

| | parent | text_model |
|---|---|---|
| before | 2 | **1** (top-level silently ignored) |
| after | 2 | **2** |

**model_1** — `rbln_config={"text_model": {"batch_size": 2, "max_seq_len": 2048}}` (vllm-rbln style)

| | parent | text_model |
|---|---|---|
| before | 1 | 2 |
| after | 1 | 2 (unchanged) |

**model_2** — `rbln_config={"batch_size": 1, "text_model": {"batch_size": 2, "max_seq_len": 2048}}`

| | parent | text_model |
|---|---|---|
| before | 1 | 2 (submodule wins) |
| after | 1 | 2 (unchanged) |

Only model_0 changes; the other two keep their dev behavior.

## Side effects checked

- Reload of saved artifacts is unaffected: `RBLNModelConfig.from_pretrained` pre-instantiates submodule dicts before calling the parent ctor, and instances bypass `initialize_submodule_config` merging entirely. Verified end-to-end (compile → `save_pretrained` → `from_pretrained`) with the model_1-style artifact (saved parent `batch_size=1`, `text_model.batch_size=2`).
- vllm-rbln builds submodule-only dicts (`{"language_model"/"text_model": {...}}`, no top-level `batch_size`) — unaffected.
- Vision towers stay pinned: an explicit `vision_tower={"batch_size": 2}` still raises as before.

## Tests

`tests/test_config.py`:
- `test_composite_vlm_batch_size_propagation` — parametrized over the six composite configs: top-level-only propagates, submodule-only works, submodule wins on both-set, equal both-set works (config level, no compile)
- `test_colqwen2_submodule_only_kwargs_no_conflict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
