### PR TITLE
performance: resolve weight and config files instead of listing the repo

### DIFF
--- a/src/optimum/rbln/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -122,15 +122,27 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         dtype: str | torch.dtype = None,
         torch_dtype: str | torch.dtype = None,
         config: PretrainedConfig | None = None,
+        token: bool | str | None = None,
+        revision: str | None = None,
+        cache_dir: str | None = None,
+        force_download: bool = False,
+        local_files_only: bool = False,
         **kwargs,
     ) -> PreTrainedModel:
         dtype = cls._get_dtype(dtype, torch_dtype)
+        hub_kwargs = {
+            "token": token,
+            "revision": revision,
+            "cache_dir": cache_dir,
+            "force_download": force_download,
+            "local_files_only": local_files_only,
+        }
 
-        safetensor_files = load_weight_files(model_id, exception_keywords=["original"])
+        safetensor_files = load_weight_files(model_id, exception_keywords=["original"], **hub_kwargs)
         state_dict = {k: v for f in safetensor_files for k, v in load_file(f).items()}
 
         if config is None:
-            config, kwargs = AutoConfig.from_pretrained(model_id, return_unused_kwargs=True)
+            config, kwargs = AutoConfig.from_pretrained(model_id, return_unused_kwargs=True, **hub_kwargs)
 
         with no_init_weights():
             model = AutoModelForCausalLM.from_config(config, dtype=dtype, **kwargs)

--- a/src/optimum/rbln/transformers/utils/rbln_quantization.py
+++ b/src/optimum/rbln/transformers/utils/rbln_quantization.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import glob
+import json
 import os
 from collections.abc import Iterable
 from typing import (
@@ -21,12 +22,14 @@ from typing import (
 )
 
 import torch
-from huggingface_hub import hf_hub_download, list_repo_files
+from huggingface_hub import hf_hub_download, list_repo_files, snapshot_download
+from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError, OfflineModeIsEnabled
 from safetensors.torch import load_file
 from torch.nn import Linear, Parameter
 from transformers import AutoConfig
 from transformers.initialization import no_init_weights
 from transformers.modeling_utils import get_state_dict_dtype
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME
 
 from ...configuration_utils import RBLNSerializableConfigProtocol
 from ...utils.logging import get_logger
@@ -240,6 +243,80 @@ def get_quantized_model(
     return model
 
 
+def _select_safetensors(filenames: Iterable[str], exception_keywords: list[str]) -> list[str]:
+    return sorted(
+        name
+        for name in filenames
+        if name.endswith(".safetensors") and not any(keyword in name for keyword in exception_keywords)
+    )
+
+
+def _shard_names_from_index(index_path: str) -> list[str]:
+    with open(index_path) as f:
+        weight_map = json.load(f).get("weight_map") or {}
+    return list(dict.fromkeys(weight_map.values()))
+
+
+def _download_optional(filename: str, **hub_kwargs) -> str | None:
+    """Download `filename`, or return None when the repo does not carry it."""
+    try:
+        return hf_hub_download(filename=filename, **hub_kwargs)
+    except EntryNotFoundError:
+        return None
+
+
+def _resolve_weight_names(
+    model_id: str,
+    exception_keywords: list[str],
+    token: bool | str | None,
+    revision: str | None,
+    cache_dir: str | None,
+    force_download: bool,
+    local_files_only: bool,
+) -> list[str]:
+    """Resolve the repo-relative safetensors names carried by a Hub repository.
+
+    The safetensors index is preferred over listing the repository, because the tree
+    endpoint is charged to the Hub's narrow `api` rate limit and, unlike `hf_hub_download`,
+    it neither retries on 429 nor falls back to the local cache.
+    """
+    hub_kwargs = {
+        "repo_id": model_id,
+        "token": token,
+        "revision": revision,
+        "cache_dir": cache_dir,
+        "force_download": force_download,
+        "local_files_only": local_files_only,
+    }
+
+    index_path = _download_optional(SAFE_WEIGHTS_INDEX_NAME, **hub_kwargs)
+    if index_path is not None:
+        names = _select_safetensors(_shard_names_from_index(index_path), exception_keywords)
+        if names:
+            return names
+
+    if _download_optional(SAFE_WEIGHTS_NAME, **hub_kwargs) is not None:
+        return _select_safetensors([SAFE_WEIGHTS_NAME], exception_keywords)
+
+    logger.warning(
+        f"{model_id} carries neither {SAFE_WEIGHTS_INDEX_NAME} nor {SAFE_WEIGHTS_NAME}, so its weight files have to be"
+        " discovered by listing the repository, which is charged to the Hub's `api` rate limit."
+    )
+    try:
+        repo_files = list_repo_files(model_id, revision=revision, token=token)
+    except (OfflineModeIsEnabled, HfHubHTTPError) as e:
+        logger.warning(f"Could not list {model_id} ({e}). Falling back to the cached snapshot.")
+        snapshot_dir = snapshot_download(
+            repo_id=model_id, revision=revision, token=token, cache_dir=cache_dir, local_files_only=True
+        )
+        repo_files = [
+            os.path.relpath(path, snapshot_dir)
+            for path in glob.glob(f"{snapshot_dir}/**/*.safetensors", recursive=True)
+        ]
+
+    return _select_safetensors(repo_files, exception_keywords)
+
+
 def load_weight_files(
     model_id: str,
     token: bool | str | None = None,
@@ -254,37 +331,30 @@ def load_weight_files(
     """
     exception_keywords = exception_keywords or []
     if os.path.isdir(model_id):
-        safetensor_files = glob.glob(f"{model_id}/*.safetensors")
+        # Keyed by name so that a keyword matching `model_id` itself cannot filter every file out.
+        by_name = {os.path.relpath(path, model_id): path for path in glob.glob(f"{model_id}/*.safetensors")}
+        safetensor_files = [by_name[name] for name in _select_safetensors(by_name, exception_keywords)]
     else:
-        try:
-            # List all files in the repository
-            repo_files = list_repo_files(model_id, revision=revision, token=token)
-            # Filter for safetensors files
-            safetensor_files = []
-
-            for file in repo_files:
-                if file.endswith(".safetensors"):
-                    exculde = False
-                    for except_key in exception_keywords:
-                        if except_key in file:
-                            exculde = True
-                            break
-
-                    if not exculde:
-                        # Download the safetensors file
-                        downloaded_file = hf_hub_download(
-                            repo_id=model_id,
-                            filename=file,
-                            revision=revision,
-                            token=token,
-                            cache_dir=cache_dir,
-                            force_download=force_download,
-                            local_files_only=local_files_only,
-                        )
-                        safetensor_files.append(downloaded_file)
-        except Exception as e:
-            logger.error(f"Failed to download safetensors files from Hugging Face Hub: {e}")
-            raise e
+        safetensor_files = [
+            hf_hub_download(
+                repo_id=model_id,
+                filename=name,
+                revision=revision,
+                token=token,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                local_files_only=local_files_only,
+            )
+            for name in _resolve_weight_names(
+                model_id,
+                exception_keywords,
+                token=token,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                local_files_only=local_files_only,
+            )
+        ]
 
     if not safetensor_files:
         raise FileNotFoundError(f"No safetensors files found for model_id: {model_id}")

--- a/src/optimum/rbln/transformers/utils/rbln_quantization.py
+++ b/src/optimum/rbln/transformers/utils/rbln_quantization.py
@@ -22,14 +22,14 @@ from typing import (
 )
 
 import torch
-from huggingface_hub import hf_hub_download, list_repo_files, snapshot_download
-from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError, OfflineModeIsEnabled
+from huggingface_hub import hf_hub_download, list_repo_files
+from huggingface_hub.errors import EntryNotFoundError
 from safetensors.torch import load_file
 from torch.nn import Linear, Parameter
 from transformers import AutoConfig
 from transformers.initialization import no_init_weights
 from transformers.modeling_utils import get_state_dict_dtype
-from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
 from ...configuration_utils import RBLNSerializableConfigProtocol
 from ...utils.logging import get_logger
@@ -243,78 +243,36 @@ def get_quantized_model(
     return model
 
 
-def _select_safetensors(filenames: Iterable[str], exception_keywords: list[str]) -> list[str]:
-    return sorted(
-        name
-        for name in filenames
-        if name.endswith(".safetensors") and not any(keyword in name for keyword in exception_keywords)
-    )
-
-
-def _shard_names_from_index(index_path: str) -> list[str]:
-    with open(index_path) as f:
-        weight_map = json.load(f).get("weight_map") or {}
-    return list(dict.fromkeys(weight_map.values()))
-
-
-def _download_optional(filename: str, **hub_kwargs) -> str | None:
-    """Download `filename`, or return None when the repo does not carry it."""
-    try:
-        return hf_hub_download(filename=filename, **hub_kwargs)
-    except EntryNotFoundError:
-        return None
-
-
 def _resolve_weight_names(
     model_id: str,
-    exception_keywords: list[str],
     token: bool | str | None,
     revision: str | None,
     cache_dir: str | None,
     force_download: bool,
     local_files_only: bool,
 ) -> list[str]:
-    """Resolve the repo-relative safetensors names carried by a Hub repository.
+    """List the files of a repo, from its safetensors index when it has one.
 
-    The safetensors index is preferred over listing the repository, because the tree
-    endpoint is charged to the Hub's narrow `api` rate limit and, unlike `hf_hub_download`,
-    it neither retries on 429 nor falls back to the local cache.
+    Listing the repository is the fallback rather than the default because, unlike
+    `hf_hub_download`, that endpoint neither retries on 429 nor falls back to the cache.
     """
-    hub_kwargs = {
-        "repo_id": model_id,
-        "token": token,
-        "revision": revision,
-        "cache_dir": cache_dir,
-        "force_download": force_download,
-        "local_files_only": local_files_only,
-    }
-
-    index_path = _download_optional(SAFE_WEIGHTS_INDEX_NAME, **hub_kwargs)
-    if index_path is not None:
-        names = _select_safetensors(_shard_names_from_index(index_path), exception_keywords)
-        if names:
-            return names
-
-    if _download_optional(SAFE_WEIGHTS_NAME, **hub_kwargs) is not None:
-        return _select_safetensors([SAFE_WEIGHTS_NAME], exception_keywords)
-
-    logger.warning(
-        f"{model_id} carries neither {SAFE_WEIGHTS_INDEX_NAME} nor {SAFE_WEIGHTS_NAME}, so its weight files have to be"
-        " discovered by listing the repository, which is charged to the Hub's `api` rate limit."
-    )
     try:
-        repo_files = list_repo_files(model_id, revision=revision, token=token)
-    except (OfflineModeIsEnabled, HfHubHTTPError) as e:
-        logger.warning(f"Could not list {model_id} ({e}). Falling back to the cached snapshot.")
-        snapshot_dir = snapshot_download(
-            repo_id=model_id, revision=revision, token=token, cache_dir=cache_dir, local_files_only=True
+        index_path = hf_hub_download(
+            repo_id=model_id,
+            filename=SAFE_WEIGHTS_INDEX_NAME,
+            revision=revision,
+            token=token,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            local_files_only=local_files_only,
         )
-        repo_files = [
-            os.path.relpath(path, snapshot_dir)
-            for path in glob.glob(f"{snapshot_dir}/**/*.safetensors", recursive=True)
-        ]
+    except EntryNotFoundError:
+        logger.warning(f"{model_id} has no {SAFE_WEIGHTS_INDEX_NAME}, so its files have to be listed from the Hub.")
+        return list_repo_files(model_id, revision=revision, token=token)
 
-    return _select_safetensors(repo_files, exception_keywords)
+    with open(index_path) as f:
+        weight_map = json.load(f).get("weight_map") or {}
+    return list(dict.fromkeys(weight_map.values()))
 
 
 def load_weight_files(
@@ -331,30 +289,36 @@ def load_weight_files(
     """
     exception_keywords = exception_keywords or []
     if os.path.isdir(model_id):
-        # Keyed by name so that a keyword matching `model_id` itself cannot filter every file out.
-        by_name = {os.path.relpath(path, model_id): path for path in glob.glob(f"{model_id}/*.safetensors")}
-        safetensor_files = [by_name[name] for name in _select_safetensors(by_name, exception_keywords)]
+        safetensor_files = glob.glob(f"{model_id}/*.safetensors")
     else:
-        safetensor_files = [
-            hf_hub_download(
-                repo_id=model_id,
-                filename=name,
-                revision=revision,
-                token=token,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                local_files_only=local_files_only,
-            )
-            for name in _resolve_weight_names(
-                model_id,
-                exception_keywords,
-                token=token,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                local_files_only=local_files_only,
-            )
-        ]
+        try:
+            repo_files = _resolve_weight_names(model_id, token, revision, cache_dir, force_download, local_files_only)
+            # Filter for safetensors files
+            safetensor_files = []
+
+            for file in repo_files:
+                if file.endswith(".safetensors"):
+                    exculde = False
+                    for except_key in exception_keywords:
+                        if except_key in file:
+                            exculde = True
+                            break
+
+                    if not exculde:
+                        # Download the safetensors file
+                        downloaded_file = hf_hub_download(
+                            repo_id=model_id,
+                            filename=file,
+                            revision=revision,
+                            token=token,
+                            cache_dir=cache_dir,
+                            force_download=force_download,
+                            local_files_only=local_files_only,
+                        )
+                        safetensor_files.append(downloaded_file)
+        except Exception as e:
+            logger.error(f"Failed to download safetensors files from Hugging Face Hub: {e}")
+            raise e
 
     if not safetensor_files:
         raise FileNotFoundError(f"No safetensors files found for model_id: {model_id}")

--- a/src/optimum/rbln/utils/hub.py
+++ b/src/optimum/rbln/utils/hub.py
@@ -16,7 +16,7 @@ import json
 from pathlib import Path
 
 from huggingface_hub import HfApi, get_token, hf_hub_download, try_to_load_from_cache
-from huggingface_hub.errors import LocalEntryNotFoundError
+from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 
 
 def pull_compiled_model_from_hub(
@@ -115,6 +115,21 @@ def pull_compiled_model_from_hub(
                 f"Could not find compiled model files for {model_id} in local cache. "
                 f"Set local_files_only=False to download from HuggingFace Hub."
             ) from err
+
+    # A repo without `rbln_config.json` holds no compiled model, and resolving that one file
+    # tells us so without listing the repository, which is charged to the Hub's `api` rate limit.
+    try:
+        hf_hub_download(
+            repo_id=model_id,
+            filename=config_filename,
+            token=token,
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            local_files_only=local_files_only,
+        )
+    except EntryNotFoundError as err:
+        raise FileNotFoundError(f"Could not find `rbln_config.json` file in repository {model_id}") from err
 
     # List files from repository. This only happens when:
     # 1. Config is not cached, OR

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import os
 import random
 import shutil
@@ -7,15 +8,19 @@ import unittest
 from collections.abc import Iterable
 from contextlib import nullcontext as does_not_raise
 from enum import Enum
+from unittest import mock
 from unittest.mock import patch
 
+import httpx
 import pytest
 import transformers
 from diffusers import DiffusionPipeline
+from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError
 from transformers import AutoConfig, CLIPConfig
 
 from optimum.rbln import __version__
 from optimum.rbln.configuration_utils import ContextRblnConfig
+from optimum.rbln.transformers.utils import rbln_quantization
 from optimum.rbln.utils.deprecation import deprecate_method
 
 
@@ -438,3 +443,84 @@ class DisallowedTestBase:
         @classmethod
         def get_rbln_local_dir(cls):
             return os.path.basename(cls.HF_MODEL_ID) + "-local"
+
+
+class TestWeightFileDiscovery:
+    """`load_weight_files` must resolve shard names without listing the repository tree.
+
+    The tree endpoint is charged to the Hub's `api` rate limit and, unlike `hf_hub_download`,
+    neither retries on 429 nor falls back to the local cache.
+    """
+
+    SHARDS = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
+
+    @staticmethod
+    def _repo(tmp_path, filenames, weight_map=None):
+        for name in filenames:
+            path = tmp_path / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+        if weight_map is not None:
+            (tmp_path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
+        served = {p.relative_to(tmp_path).as_posix(): str(p) for p in tmp_path.rglob("*") if p.is_file()}
+
+        def download(repo_id, filename, **kwargs):
+            if filename not in served:
+                raise EntryNotFoundError(f"{filename} not found in {repo_id}")
+            return served[filename]
+
+        return download
+
+    def _load(self, download, list_repo_files=None, snapshot_download=None, **kwargs):
+        no_tree = mock.Mock(side_effect=AssertionError("list_repo_files must not be called"))
+        with (
+            mock.patch.object(rbln_quantization, "hf_hub_download", download),
+            mock.patch.object(rbln_quantization, "list_repo_files", list_repo_files or no_tree),
+            mock.patch.object(rbln_quantization, "snapshot_download", snapshot_download or no_tree),
+        ):
+            return [os.path.basename(p) for p in rbln_quantization.load_weight_files("dummy/repo", **kwargs)]
+
+    def test_index_resolves_shards_without_listing_the_tree(self, tmp_path):
+        weight_map = {f"layer.{i}.weight": self.SHARDS[i % 2] for i in range(64)}
+        download = self._repo(tmp_path, self.SHARDS, weight_map)
+
+        assert self._load(download) == self.SHARDS
+
+    def test_index_shards_are_deduplicated(self, tmp_path):
+        weight_map = {f"layer.{i}.weight": self.SHARDS[0] for i in range(64)}
+        download = self._repo(tmp_path, self.SHARDS, weight_map)
+
+        assert self._load(download) == [self.SHARDS[0]]
+
+    def test_repo_without_index_falls_back_to_the_single_weight_file(self, tmp_path):
+        download = self._repo(tmp_path, ["model.safetensors"])
+
+        assert self._load(download) == ["model.safetensors"]
+
+    def test_repo_without_index_or_single_file_lists_the_tree(self, tmp_path):
+        download = self._repo(tmp_path, ["custom-000.safetensors", "original/model.safetensors"])
+        listing = mock.Mock(return_value=["custom-000.safetensors", "original/model.safetensors", "config.json"])
+
+        files = self._load(download, list_repo_files=listing, exception_keywords=["original"])
+
+        assert files == ["custom-000.safetensors"]
+        listing.assert_called_once()
+
+    def test_unlistable_repo_falls_back_to_the_cached_snapshot(self, tmp_path):
+        download = self._repo(tmp_path, ["custom-000.safetensors"])
+        response = httpx.Response(429, request=httpx.Request("GET", "https://huggingface.co/api/models/dummy/repo"))
+        rate_limited = mock.Mock(side_effect=HfHubHTTPError("429 Too Many Requests", response=response))
+
+        files = self._load(download, list_repo_files=rate_limited, snapshot_download=lambda **kw: str(tmp_path))
+
+        assert files == ["custom-000.safetensors"]
+
+    def test_local_directory_keyword_is_matched_against_the_file_name(self, tmp_path):
+        model_dir = tmp_path / "original-checkpoint"
+        model_dir.mkdir()
+        for name in self.SHARDS:
+            (model_dir / name).touch()
+
+        files = rbln_quantization.load_weight_files(str(model_dir), exception_keywords=["original"])
+
+        assert [os.path.basename(p) for p in files] == self.SHARDS

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 import os
 import random
 import shutil
@@ -8,19 +7,15 @@ import unittest
 from collections.abc import Iterable
 from contextlib import nullcontext as does_not_raise
 from enum import Enum
-from unittest import mock
 from unittest.mock import patch
 
-import httpx
 import pytest
 import transformers
 from diffusers import DiffusionPipeline
-from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError
 from transformers import AutoConfig, CLIPConfig
 
 from optimum.rbln import __version__
 from optimum.rbln.configuration_utils import ContextRblnConfig
-from optimum.rbln.transformers.utils import rbln_quantization
 from optimum.rbln.utils.deprecation import deprecate_method
 
 
@@ -443,84 +438,3 @@ class DisallowedTestBase:
         @classmethod
         def get_rbln_local_dir(cls):
             return os.path.basename(cls.HF_MODEL_ID) + "-local"
-
-
-class TestWeightFileDiscovery:
-    """`load_weight_files` must resolve shard names without listing the repository tree.
-
-    The tree endpoint is charged to the Hub's `api` rate limit and, unlike `hf_hub_download`,
-    neither retries on 429 nor falls back to the local cache.
-    """
-
-    SHARDS = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
-
-    @staticmethod
-    def _repo(tmp_path, filenames, weight_map=None):
-        for name in filenames:
-            path = tmp_path / name
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.touch()
-        if weight_map is not None:
-            (tmp_path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
-        served = {p.relative_to(tmp_path).as_posix(): str(p) for p in tmp_path.rglob("*") if p.is_file()}
-
-        def download(repo_id, filename, **kwargs):
-            if filename not in served:
-                raise EntryNotFoundError(f"{filename} not found in {repo_id}")
-            return served[filename]
-
-        return download
-
-    def _load(self, download, list_repo_files=None, snapshot_download=None, **kwargs):
-        no_tree = mock.Mock(side_effect=AssertionError("list_repo_files must not be called"))
-        with (
-            mock.patch.object(rbln_quantization, "hf_hub_download", download),
-            mock.patch.object(rbln_quantization, "list_repo_files", list_repo_files or no_tree),
-            mock.patch.object(rbln_quantization, "snapshot_download", snapshot_download or no_tree),
-        ):
-            return [os.path.basename(p) for p in rbln_quantization.load_weight_files("dummy/repo", **kwargs)]
-
-    def test_index_resolves_shards_without_listing_the_tree(self, tmp_path):
-        weight_map = {f"layer.{i}.weight": self.SHARDS[i % 2] for i in range(64)}
-        download = self._repo(tmp_path, self.SHARDS, weight_map)
-
-        assert self._load(download) == self.SHARDS
-
-    def test_index_shards_are_deduplicated(self, tmp_path):
-        weight_map = {f"layer.{i}.weight": self.SHARDS[0] for i in range(64)}
-        download = self._repo(tmp_path, self.SHARDS, weight_map)
-
-        assert self._load(download) == [self.SHARDS[0]]
-
-    def test_repo_without_index_falls_back_to_the_single_weight_file(self, tmp_path):
-        download = self._repo(tmp_path, ["model.safetensors"])
-
-        assert self._load(download) == ["model.safetensors"]
-
-    def test_repo_without_index_or_single_file_lists_the_tree(self, tmp_path):
-        download = self._repo(tmp_path, ["custom-000.safetensors", "original/model.safetensors"])
-        listing = mock.Mock(return_value=["custom-000.safetensors", "original/model.safetensors", "config.json"])
-
-        files = self._load(download, list_repo_files=listing, exception_keywords=["original"])
-
-        assert files == ["custom-000.safetensors"]
-        listing.assert_called_once()
-
-    def test_unlistable_repo_falls_back_to_the_cached_snapshot(self, tmp_path):
-        download = self._repo(tmp_path, ["custom-000.safetensors"])
-        response = httpx.Response(429, request=httpx.Request("GET", "https://huggingface.co/api/models/dummy/repo"))
-        rate_limited = mock.Mock(side_effect=HfHubHTTPError("429 Too Many Requests", response=response))
-
-        files = self._load(download, list_repo_files=rate_limited, snapshot_download=lambda **kw: str(tmp_path))
-
-        assert files == ["custom-000.safetensors"]
-
-    def test_local_directory_keyword_is_matched_against_the_file_name(self, tmp_path):
-        model_dir = tmp_path / "original-checkpoint"
-        model_dir.mkdir()
-        for name in self.SHARDS:
-            (model_dir / name).touch()
-
-        files = rbln_quantization.load_weight_files(str(model_dir), exception_keywords=["original"])
-
-        assert [os.path.basename(p) for p in files] == self.SHARDS


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview
- `load_weight_files` reads the weight file names from `model.safetensors.index.json`, and lists the repository only when the repo has no index.
- `pull_compiled_model_from_hub` resolves `rbln_config.json` to decide whether a repo holds a compiled model. Only a repo that actually carries one is listed.
- `RBLNGptOssForCausalLM.get_pytorch_model` forwards `token` / `revision` / `cache_dir` / `force_download` / `local_files_only`, which it previously dropped.

## Motivation and Context
Both call sites listed the repository on every load, even when the files were already in the local cache. Unlike `hf_hub_download`, that endpoint neither retries on 429 nor falls back to the cache, so one rate-limited response failed the whole load.

`_is_compiled` runs for every `from_pretrained`, so the listing happened once per model even though a plain Hub model never holds a compiled one. Resolving a single file answers the same question, keeps the request on the cache-validating path, and lets `local_files_only=True` and `HF_HUB_OFFLINE=1` work where listing used to raise.

## Related Issues