### PR TITLE
other(tests): serve HF loads from the local cache before calling the Hub

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -102,6 +102,15 @@ def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise
         stub()
 
 
+def from_pretrained_cache_first(loader, model_id, **kwargs):
+    # Serve from the local HF cache without any Hub API call (CI shares one
+    # account-level rate limit); go online only on a cache miss.
+    try:
+        return loader.from_pretrained(model_id, local_files_only=True, **kwargs)
+    except OSError:
+        return loader.from_pretrained(model_id, **kwargs)
+
+
 DUMMY_DEVICE_CODE = -1
 
 
@@ -234,7 +243,8 @@ class BaseTest:
                 if os.path.exists(cls.get_rbln_local_dir()):
                     shutil.rmtree(cls.get_rbln_local_dir())
                 with ContextRblnConfig(device=cls.DEVICE):
-                    cls.model = cls.RBLN_CLASS.from_pretrained(
+                    cls.model = from_pretrained_cache_first(
+                        cls.RBLN_CLASS,
                         cls.HF_MODEL_ID,
                         model_save_dir=cls.get_rbln_local_dir(),
                         **cls.RBLN_CLASS_KWARGS,
@@ -419,7 +429,8 @@ class DisallowedTestBase:
 
         def test_load(self):
             try:
-                _ = self.RBLN_CLASS.from_pretrained(
+                _ = from_pretrained_cache_first(
+                    self.RBLN_CLASS,
                     self.HF_MODEL_ID,
                     model_save_dir=self.get_rbln_local_dir(),
                     **self.RBLN_CLASS_KWARGS,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,8 @@ from optimum.rbln import (
     RBLNStableDiffusionPipeline,
 )
 
+from .test_base import from_pretrained_cache_first
+
 
 @pytest.fixture
 def model_id():
@@ -29,7 +31,8 @@ def model_id():
 
 @pytest.fixture
 def stable_diffusion_model():
-    model = RBLNStableDiffusionPipeline.from_pretrained(
+    model = from_pretrained_cache_first(
+        RBLNStableDiffusionPipeline,
         "hf-internal-testing/tiny-sd-pipe",
         export=True,
         rbln_config={
@@ -58,8 +61,8 @@ def test_stable_diffusion_config(stable_diffusion_model):
 
 def test_explicit_config_parameters(model_id):
     """Test loading model with explicit configuration parameters."""
-    model = RBLNResNetForImageClassification.from_pretrained(
-        model_id, rbln_image_size=224, rbln_batch_size=2, rbln_create_runtimes=False
+    model = from_pretrained_cache_first(
+        RBLNResNetForImageClassification, model_id, rbln_image_size=224, rbln_batch_size=2, rbln_create_runtimes=False
     )
     assert model is not None
     assert hasattr(model, "rbln_config")
@@ -70,7 +73,7 @@ def test_config_dict(model_id):
     """Test loading model with configuration passed as a dictionary."""
     rbln_config = {"create_runtimes": False, "image_size": 64}
 
-    model = RBLNResNetForImageClassification.from_pretrained(model_id, rbln_config=rbln_config)
+    model = from_pretrained_cache_first(RBLNResNetForImageClassification, model_id, rbln_config=rbln_config)
     assert model is not None
     assert hasattr(model, "rbln_config")
     assert model.rbln_config.image_size == 64
@@ -87,7 +90,7 @@ def test_config_object(model_id):
     compile_cfg = RBLNCompileConfig(input_info=[("pixel_values", (1, 3, 224, 224), "float32")])
     config.set_compile_cfgs([compile_cfg])
 
-    model = RBLNResNetForImageClassification.from_pretrained(model_id, rbln_config=config)
+    model = from_pretrained_cache_first(RBLNResNetForImageClassification, model_id, rbln_config=config)
     assert model is not None
     assert hasattr(model, "rbln_config")
     # Pre-configured object should be properly applied
@@ -102,7 +105,8 @@ def test_mixed_config_approach(model_id):
     compile_cfg = RBLNCompileConfig(input_info=[("pixel_values", (1, 3, 224, 224), "float32")])
     config.set_compile_cfgs([compile_cfg])
 
-    model = RBLNResNetForImageClassification.from_pretrained(
+    model = from_pretrained_cache_first(
+        RBLNResNetForImageClassification,
         model_id,
         export=True,
         rbln_config=config,
@@ -123,8 +127,8 @@ def test_config_persistence_after_reload(model_id, tmp_path):
     os.makedirs(save_dir, exist_ok=True)
 
     # Use distinctive values to ensure we can detect them
-    original_model = RBLNResNetForImageClassification.from_pretrained(
-        model_id, rbln_image_size=112, rbln_batch_size=3, rbln_create_runtimes=False
+    original_model = from_pretrained_cache_first(
+        RBLNResNetForImageClassification, model_id, rbln_image_size=112, rbln_batch_size=3, rbln_create_runtimes=False
     )
     original_model.save_pretrained(save_dir)
 
@@ -147,7 +151,8 @@ def test_config_priority(model_id):
     config.create_runtimes = False
 
     # This explicit parameter should override the config object setting
-    model = RBLNResNetForImageClassification.from_pretrained(
+    model = from_pretrained_cache_first(
+        RBLNResNetForImageClassification,
         model_id,
         export=True,
         rbln_config=config,
@@ -194,7 +199,8 @@ def test_load_config_object(model_id, tmp_path):
 
 def test_submodule_config_dict():
     """Test loading submodule model with configuration passed as a dictionary."""
-    model = RBLNLlavaNextForConditionalGeneration.from_pretrained(
+    model = from_pretrained_cache_first(
+        RBLNLlavaNextForConditionalGeneration,
         "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
         export=True,
         rbln_language_model={"max_seq_len": 16384, "use_inputs_embeds": True, "batch_size": 2},
@@ -208,7 +214,8 @@ def test_submodule_config_object():
 
     rbln_config = RBLNMistralForCausalLMConfig(max_seq_len=16384, use_inputs_embeds=True, batch_size=2)
 
-    model = RBLNLlavaNextForConditionalGeneration.from_pretrained(
+    model = from_pretrained_cache_first(
+        RBLNLlavaNextForConditionalGeneration,
         "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
         export=True,
         rbln_language_model=rbln_config,
@@ -317,7 +324,7 @@ def test_invalid_config_parameters(model_id, invalid_param):
             pytest.skip("Sufficient devices for invalid rbln_device check")
 
     with pytest.raises((ValueError, TypeError)):
-        _ = RBLNResNetForImageClassification.from_pretrained(model_id, **invalid_param)
+        _ = from_pretrained_cache_first(RBLNResNetForImageClassification, model_id, **invalid_param)
 
 
 def test_custom_class(model_id):
@@ -347,7 +354,7 @@ def test_custom_class(model_id):
 
     RBLNAutoModel.register(RBLNResNetModel)
     RBLNAutoConfig.register(RBLNResNetModelConfig)
-    my_model = RBLNResNetModel.from_pretrained(model_id, rbln_device=-1)
+    my_model = from_pretrained_cache_first(RBLNResNetModel, model_id, rbln_device=-1)
     random_image_input = torch.randn(1, 3, 64, 64)
     _ = my_model(random_image_input)
 
@@ -397,7 +404,8 @@ def test_prefill_chunk_size_npu_wiring_e2e(tmp_path):
     """Compile-time wiring: `rbln_config.npu` flows through `_update_attention_config` into the
     NPU-aware `prefill_chunk_size` default (512 on RBLN-CR) and survives save/reload.
     Pinning `npu` compiles for RBLN-CR03 without a CR device attached."""
-    model = RBLNLlamaForCausalLM.from_pretrained(
+    model = from_pretrained_cache_first(
+        RBLNLlamaForCausalLM,
         "afmck/testing-llama-tiny",
         export=True,
         num_hidden_layers=1,

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -19,7 +19,7 @@ from optimum.rbln import (
     RBLNStableVideoDiffusionPipeline,
 )
 
-from .test_base import BaseHubTest, BaseTest
+from .test_base import BaseHubTest, BaseTest, from_pretrained_cache_first
 
 
 class TestSDModel(BaseTest.TestModel, BaseHubTest.TestHub):
@@ -137,7 +137,7 @@ class TestSDControlNetModel(BaseTest.TestModel):
 
     @classmethod
     def setUpClass(cls):
-        controlnet = ControlNetModel.from_pretrained(cls.CONTROLNET_ID)
+        controlnet = from_pretrained_cache_first(ControlNetModel, cls.CONTROLNET_ID)
         cls.RBLN_CLASS_KWARGS["controlnet"] = controlnet
         return super().setUpClass()
 
@@ -168,7 +168,7 @@ class TestSDXLControlNetModel(BaseTest.TestModel):
 
     @classmethod
     def setUpClass(cls):
-        controlnet = ControlNetModel.from_pretrained(cls.CONTROLNET_ID)
+        controlnet = from_pretrained_cache_first(ControlNetModel, cls.CONTROLNET_ID)
         cls.RBLN_CLASS_KWARGS["controlnet"] = controlnet
         return super().setUpClass()
 
@@ -239,8 +239,8 @@ class TestSDMultiControlNetModel(BaseTest.TestModel):
 
     @classmethod
     def setUpClass(cls):
-        controlnet = ControlNetModel.from_pretrained(cls.CONTROLNET_ID)
-        controlnet_1 = ControlNetModel.from_pretrained(cls.CONTROLNET_ID)
+        controlnet = from_pretrained_cache_first(ControlNetModel, cls.CONTROLNET_ID)
+        controlnet_1 = from_pretrained_cache_first(ControlNetModel, cls.CONTROLNET_ID)
         controlnets = [controlnet, controlnet_1]
         cls.RBLN_CLASS_KWARGS["controlnet"] = controlnets
         return super().setUpClass()
@@ -282,7 +282,7 @@ class TestKandinskyV22Model(BaseTest.TestModel):
         rbln_class_kwargs_copy = self.RBLN_CLASS_KWARGS.copy()
         rbln_class_kwargs_copy["rbln_config"] = rbln_config
         with self.subTest():
-            _ = self.RBLN_CLASS.from_pretrained(model_id=self.HF_MODEL_ID, **rbln_class_kwargs_copy)
+            _ = from_pretrained_cache_first(self.RBLN_CLASS, self.HF_MODEL_ID, **rbln_class_kwargs_copy)
         with self.subTest():
             self.assertEqual(_.prior_text_encoder.rbln_config.batch_size, 2)
             self.assertEqual(_.prior_prior.rbln_config.batch_size, 4)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -48,7 +48,7 @@ from optimum.rbln import (
     RBLNT5ForConditionalGeneration,
 )
 
-from .test_base import BaseTest, DisallowedTestBase, TestLevel
+from .test_base import BaseTest, DisallowedTestBase, TestLevel, from_pretrained_cache_first
 
 
 RANDOM_ATTN_MASK = torch.randint(low=0, high=2, size=(1, 512), generator=torch.manual_seed(42), dtype=torch.int64)
@@ -67,10 +67,15 @@ class LLMTest:
         HF_CONFIG_KWARGS_PREPROCESSOR = {"padding_side": "left"}
 
         def get_tokenizer(self):
-            PreProcessor = AutoProcessor if self.IS_MULTIMODAL else AutoTokenizer
-            if getattr(self, "_tokenizer", None) is None:
-                self._tokenizer = PreProcessor.from_pretrained(self.HF_MODEL_ID, **self.HF_CONFIG_KWARGS_PREPROCESSOR)
-            return self._tokenizer
+            # Cache on the concrete class: unittest builds a new instance per test
+            # method, so an instance attribute reloads the tokenizer every test.
+            cls = type(self)
+            if "_tokenizer" not in cls.__dict__:
+                PreProcessor = AutoProcessor if self.IS_MULTIMODAL else AutoTokenizer
+                cls._tokenizer = from_pretrained_cache_first(
+                    PreProcessor, self.HF_MODEL_ID, **self.HF_CONFIG_KWARGS_PREPROCESSOR
+                )
+            return cls._tokenizer
 
         def get_inputs(self):
             self.get_tokenizer().pad_token = self.get_tokenizer().eos_token
@@ -255,7 +260,7 @@ class TestQwen3MoeForCausalLM(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         config.num_hidden_layers = 3
         config.max_position_embeddings = 4096
         config.hidden_size = 128
@@ -276,7 +281,7 @@ class TestQwen3_5ForCausalLM(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID).get_text_config()
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID).get_text_config()
         config.num_hidden_layers = 4
         config.layer_types = ["linear_attention", "linear_attention", "linear_attention", "full_attention"]
         cls.HF_CONFIG_KWARGS.update({"config": config, "ignore_mismatched_sizes": True})
@@ -552,7 +557,7 @@ class TestLlavaNextForConditionalGeneration(LLMTest.TestLLM):
     # override
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID, revision=cls.HF_CONFIG_KWARGS["revision"])
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID, revision=cls.HF_CONFIG_KWARGS["revision"])
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 1
         kwargs = {"text_config": text_config}
@@ -610,7 +615,7 @@ class TestLlavaNextForConditionalGeneration(LLMTest.TestLLM):
             ValueError,
             match="Parameter conflict for 'batch_size': submodule_config has 2, but the parent config requires 1",
         ):
-            _ = self.RBLN_CLASS.from_pretrained(model_id=self.HF_MODEL_ID, **rbln_class_kwargs)
+            _ = from_pretrained_cache_first(self.RBLN_CLASS, self.HF_MODEL_ID, **rbln_class_kwargs)
 
     def test_propagate_config(self):
         rbln_config = {
@@ -618,7 +623,7 @@ class TestLlavaNextForConditionalGeneration(LLMTest.TestLLM):
         }
         rbln_class_kwargs = {"rbln_config": rbln_config}
 
-        model = self.RBLN_CLASS.from_pretrained(model_id=self.HF_MODEL_ID, **rbln_class_kwargs)
+        model = from_pretrained_cache_first(self.RBLN_CLASS, self.HF_MODEL_ID, **rbln_class_kwargs)
 
         assert not model.rbln_config.vision_tower.create_runtimes
         assert not model.rbln_config.language_model.create_runtimes
@@ -636,7 +641,7 @@ class TestBlip2ForConditionalGeneration(LLMTest.TestLLM):
     # override
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
 
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 1
@@ -685,7 +690,7 @@ class TestIdefics3ForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 1
         kwargs = {"text_config": text_config}
@@ -778,7 +783,7 @@ class TestQwen2VLForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         vision_config = json.loads(config.vision_config.to_json_string())
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 1
@@ -791,8 +796,8 @@ class TestQwen2VLForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def get_tokenizer(cls):
-        if getattr(cls, "_tokenizer", None) is None:
-            cls._tokenizer = AutoProcessor.from_pretrained(cls.HF_MODEL_ID, max_pixels=64 * 14 * 14)
+        if "_tokenizer" not in cls.__dict__:
+            cls._tokenizer = from_pretrained_cache_first(AutoProcessor, cls.HF_MODEL_ID, max_pixels=64 * 14 * 14)
         return cls._tokenizer
 
     def get_inputs(self):
@@ -807,7 +812,7 @@ class TestQwen2VLForConditionalGeneration(LLMTest.TestLLM):
     def test_propagate_config(self):
         self.RBLN_CLASS_KWARGS["rbln_config"].update({"create_runtimes": False})
 
-        model = self.RBLN_CLASS.from_pretrained(model_id=self.HF_MODEL_ID, **self.RBLN_CLASS_KWARGS)
+        model = from_pretrained_cache_first(self.RBLN_CLASS, self.HF_MODEL_ID, **self.RBLN_CLASS_KWARGS)
 
         assert not model.rbln_config.visual.create_runtimes
         assert not model.rbln_config.create_runtimes
@@ -832,7 +837,7 @@ class TestQwen2_5_VLForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         vision_config = json.loads(config.vision_config.to_json_string())
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 1
@@ -855,7 +860,7 @@ class TestQwen2_5_VLForConditionalGeneration(LLMTest.TestLLM):
     def test_propagate_config(self):
         self.RBLN_CLASS_KWARGS["rbln_config"].update({"create_runtimes": False})
 
-        model = self.RBLN_CLASS.from_pretrained(model_id=self.HF_MODEL_ID, **self.RBLN_CLASS_KWARGS)
+        model = from_pretrained_cache_first(self.RBLN_CLASS, self.HF_MODEL_ID, **self.RBLN_CLASS_KWARGS)
 
         assert not model.rbln_config.visual.create_runtimes
         assert not model.rbln_config.create_runtimes
@@ -880,7 +885,7 @@ class TestQwen3VLForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 1
         kwargs = {"text_config": text_config}
@@ -899,7 +904,7 @@ class TestQwen3VLForConditionalGeneration(LLMTest.TestLLM):
     def test_propagate_config(self):
         self.RBLN_CLASS_KWARGS["rbln_config"].update({"create_runtimes": False})
 
-        model = self.RBLN_CLASS.from_pretrained(model_id=self.HF_MODEL_ID, **self.RBLN_CLASS_KWARGS)
+        model = from_pretrained_cache_first(self.RBLN_CLASS, self.HF_MODEL_ID, **self.RBLN_CLASS_KWARGS)
 
         assert not model.rbln_config.visual.create_runtimes
         assert not model.rbln_config.create_runtimes
@@ -965,7 +970,7 @@ class TestQwen3VLMoeForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         text_config = json.loads(config.text_config.to_json_string())
         vision_config = json.loads(config.vision_config.to_json_string())
         vision_config["depth"] = 1
@@ -1004,7 +1009,7 @@ class TestQwen3_5ForConditionalGeneration(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 4
         text_config["layer_types"] = ["linear_attention", "linear_attention", "linear_attention", "full_attention"]
@@ -1077,7 +1082,7 @@ class TestGemma3ForConditionalGeneration(LLMTest.TestLLM):
     # override
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID, revision=cls.HF_CONFIG_KWARGS["revision"])
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID, revision=cls.HF_CONFIG_KWARGS["revision"])
         text_config = json.loads(config.text_config.to_json_string())
         text_config["num_hidden_layers"] = 2
         text_config["layer_types"] = ["full_attention", "sliding_attention"]
@@ -1120,7 +1125,7 @@ class TestGemma3ForCausalLM(LLMTest.TestLLM):
 
     @classmethod
     def setUpClass(cls):
-        hf_config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        hf_config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
         hf_config.num_hidden_layers = 2
         hf_config.layer_types = ["full_attention", "sliding_attention"]
         hf_config.sliding_window_pattern = 2

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -48,7 +48,7 @@ from optimum.rbln.transformers.models.auto.modeling_auto import (
 from optimum.rbln.utils.runtime_utils import ContextRblnConfig
 from optimum.rbln.utils.save_utils import maybe_load_preprocessors
 
-from .test_base import BaseHubTest, BaseTest, TestLevel
+from .test_base import BaseHubTest, BaseTest, TestLevel, from_pretrained_cache_first
 
 
 RANDOM_INPUT_IDS = torch.randint(low=0, high=50, size=(1, 512), generator=torch.manual_seed(42), dtype=torch.int64)
@@ -86,7 +86,8 @@ class TestResNetModel(BaseTest.TestModel, BaseHubTest.TestHub):
             HF_CLASS = self.HF_AUTO_CLASS or self.HF_CLASS
             with ContextRblnConfig(device=self.DEVICE):
                 preprocessors = maybe_load_preprocessors(self.HF_MODEL_ID)
-                model = HF_CLASS.from_pretrained(
+                model = from_pretrained_cache_first(
+                    HF_CLASS,
                     self.HF_MODEL_ID,
                     **self.HF_CONFIG_KWARGS,
                     **{
@@ -112,7 +113,8 @@ class TestResNetModel(BaseTest.TestModel, BaseHubTest.TestHub):
 
     def test_failed_to_create_runtime(self):
         with self.assertRaises(ValueError):
-            _ = self.RBLN_CLASS.from_pretrained(
+            _ = from_pretrained_cache_first(
+                self.RBLN_CLASS,
                 self.HF_MODEL_ID,
                 export=True,
                 rbln_device=[0, 1, 2, 3],
@@ -190,8 +192,8 @@ class TestT5EncoderModel(BaseTest.TestModel):
             if os.path.exists(cls.get_rbln_local_dir()):
                 shutil.rmtree(cls.get_rbln_local_dir())
 
-            t5_encoder_model = T5EncoderModel.from_pretrained(
-                cls.HF_MODEL_ID, return_dict=False, **cls.HF_CONFIG_KWARGS
+            t5_encoder_model = from_pretrained_cache_first(
+                T5EncoderModel, cls.HF_MODEL_ID, return_dict=False, **cls.HF_CONFIG_KWARGS
             )
             cls.model = cls.RBLN_CLASS.from_model(
                 model=t5_encoder_model,
@@ -256,7 +258,7 @@ class TestWhisperModel(BaseTest.TestModel):
         import numpy as np
         from transformers import AutoProcessor, pipeline
 
-        processor = AutoProcessor.from_pretrained(self.HF_MODEL_ID)
+        processor = from_pretrained_cache_first(AutoProcessor, self.HF_MODEL_ID)
 
         pipe = pipeline(
             "automatic-speech-recognition",
@@ -531,7 +533,7 @@ class TestColQwen2Model(BaseTest.TestModel):
 
     @classmethod
     def setUpClass(cls):
-        config = AutoConfig.from_pretrained(cls.HF_MODEL_ID)
+        config = from_pretrained_cache_first(AutoConfig, cls.HF_MODEL_ID)
 
         # Reduce model size for faster testing
         vision_config = json.loads(config.vlm_config.vision_config.to_json_string())
@@ -547,7 +549,7 @@ class TestColQwen2Model(BaseTest.TestModel):
     def get_processor(self):
         from transformers import ColQwen2Processor
 
-        processor = ColQwen2Processor.from_pretrained(self.HF_MODEL_ID)
+        processor = from_pretrained_cache_first(ColQwen2Processor, self.HF_MODEL_ID)
         return processor
 
     def get_inputs(self):
@@ -747,7 +749,8 @@ class TestGroundingDinoModel(BaseTest.TestModel):
     def setUpClass(cls):
         from transformers import GroundingDinoConfig
 
-        config = GroundingDinoConfig.from_pretrained(
+        config = from_pretrained_cache_first(
+            GroundingDinoConfig,
             cls.HF_MODEL_ID,
             # with `decoder_bbox_embed_share=True` v5 ties
             # `bbox_embed.0` into `bbox_embed.[1+]`, and its tie_weights


### PR DESCRIPTION
## What
Mitigation for the HF rate-limit incident (option 1: code-level cache-first fallback).

Wraps every test-side `from_pretrained` call that takes a hub model id in a `from_pretrained_cache_first()` helper:

```python
try:
    return loader.from_pretrained(model_id, local_files_only=True, **kwargs)
except OSError:
    return loader.from_pretrained(model_id, **kwargs)
```

- With a warm cache, tests make **zero** Hub API calls (no etag HEAD requests at all).
- On a cache miss (e.g. a PR adding a new model), it falls back to the normal online download.
- Also moves the `test_llm.py` tokenizer cache from the instance to the concrete class: unittest builds a new instance per test method, so the tokenizer was re-resolved against the Hub on every single test.

## Why
Even with a warm HF_HOME cache, `from_pretrained` fires an etag HEAD request per resolved file, and those count against the account-wide HF rate limit (~94 test classes x several requests each, plus the per-method tokenizer reloads = hundreds to ~1k requests per PR CI run). Since the account is shared with the vllm-rbln and compiler CIs, this was a major contributor to the recent rate-limit incident.

## Verification
- `pytest --collect-only`: all 5 test modules import, 778 tests collected, no errors
- Helper smoke test: cache-hit path (offline reload succeeds) and miss path (OSError, then online fallback) both verified
- `ruff check` / `ruff format` pass

Related: the CI-level two-phase approach (cache warming + `HF_HUB_OFFLINE=1`) is proposed separately in #686. Only one of the two should be adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)