### PR TITLE
other(ci): warm the HF cache once, then run pytest fully offline

### DIFF
--- a/.github/scripts/warm_hf_cache.py
+++ b/.github/scripts/warm_hf_cache.py
@@ -1,0 +1,138 @@
+# /// script
+# dependencies = ["huggingface_hub"]
+# ///
+"""Warm the local HF cache for every Hub repo the test suite references.
+
+Run this online before pytest; the suite itself runs with HF_HUB_OFFLINE=1 so a
+warm cache produces zero Hub API calls. Only repos missing from the cache are
+downloaded, so in steady state this script is also network-silent.
+
+Usage: python warm_hf_cache.py [--dry-run]
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_PATHS = [
+    REPO_ROOT / "tests",
+    REPO_ROOT / ".github" / "scripts" / "test_cli.py",
+]
+REPO_ID_RE = re.compile(r"^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$")
+# Repo-shaped strings that are not Hub repos (e.g. placeholder ids used with an
+# in-memory config).
+DENYLIST = {"dummy/mistral"}
+COMMIT_HASH_RE = re.compile(r"^[0-9a-f]{40}$")
+NON_REPO_SUFFIX_RE = re.compile(
+    r"\.(png|jpe?g|gif|bmp|webp|json|jsonl|txt|md|py|csv|tsv|wav|mp3|mp4|safetensors|bin|pt|pth|rbln|ya?ml|lock|toml|log|so)$",
+    re.IGNORECASE,
+)
+# Files a test-time from_pretrained never reads; skipping them keeps a fresh
+# warm-up from downloading duplicate or alternative-format checkpoints.
+IGNORE_PATTERNS = [
+    "*.gguf",
+    "*.onnx",
+    "*.onnx_data",
+    "*.msgpack",
+    "*.h5",
+    "*.tflite",
+    "*.ot",
+    "*consolidated*",
+    "original/*",
+]
+
+
+def looks_like_repo_id(value: str) -> bool:
+    return bool(REPO_ID_RE.match(value)) and not NON_REPO_SUFFIX_RE.search(value) and value not in DENYLIST
+
+
+def string_constants(node: ast.AST):
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+            yield sub.value
+
+
+def collect_candidates(paths):
+    """Yield (repo_id, revision or None) referenced by the scanned sources.
+
+    A pinned revision (a 40-hex "revision" literal) is associated only with the
+    HF_MODEL_ID assigned in the same class body; every other repo-shaped string
+    is warmed at its default revision.
+    """
+    candidates = {}
+    files = []
+    for path in paths:
+        files.extend(sorted(path.rglob("*.py")) if path.is_dir() else [path])
+
+    for file in files:
+        tree = ast.parse(file.read_text(), filename=str(file))
+        class_nodes = [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]
+
+        for cls in class_nodes:
+            model_id = None
+            revision = None
+            for stmt in cls.body:
+                if isinstance(stmt, ast.Assign) and any(
+                    isinstance(t, ast.Name) and t.id == "HF_MODEL_ID" for t in stmt.targets
+                ):
+                    if isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str):
+                        model_id = stmt.value.value
+            for value in string_constants(cls):
+                if COMMIT_HASH_RE.match(value):
+                    revision = value
+            if model_id and looks_like_repo_id(model_id):
+                candidates.setdefault((model_id, revision), file.name)
+
+        for value in string_constants(tree):
+            if looks_like_repo_id(value):
+                candidates.setdefault((value, None), file.name)
+
+    return dict(sorted(candidates.items(), key=lambda item: (item[0][0], item[0][1] or "")))
+
+
+def is_cached(repo_id: str, revision: str | None) -> bool:
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    repo_dir = Path(HF_HUB_CACHE) / f"models--{repo_id.replace('/', '--')}"
+    if revision:
+        return (repo_dir / "snapshots" / revision).is_dir()
+    # An unpinned load resolves the "main" ref, so the ref and its snapshot must both exist.
+    ref = repo_dir / "refs" / "main"
+    if not ref.is_file():
+        return False
+    return (repo_dir / "snapshots" / ref.read_text().strip()).is_dir()
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    candidates = collect_candidates(SCAN_PATHS)
+
+    missing = [(repo, rev) for (repo, rev) in candidates if not is_cached(repo, rev)]
+    print(f"{len(candidates)} repo candidates, {len(missing)} not in cache")
+    if dry_run:
+        for repo, rev in candidates:
+            state = "cached" if (repo, rev) not in missing else "MISSING"
+            print(f"  [{state}] {repo}" + (f" @ {rev}" if rev else ""))
+        return 0
+
+    from huggingface_hub import snapshot_download
+
+    failures = []
+    for repo, rev in missing:
+        try:
+            snapshot_download(repo, revision=rev, ignore_patterns=IGNORE_PATTERNS)
+            print(f"warmed {repo}" + (f" @ {rev}" if rev else ""))
+        except Exception as err:  # noqa: BLE001 - a false-positive candidate must not fail the build
+            failures.append((repo, rev, err))
+            print(f"warning: could not warm {repo}: {err}")
+
+    if failures:
+        print(f"{len(failures)} candidate(s) skipped; if a test needs one of them it will fail offline")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/rbln_optimum_pytest.yaml
+++ b/.github/workflows/rbln_optimum_pytest.yaml
@@ -43,6 +43,7 @@ on:
 
 env:
   HF_HOME: ${{ secrets.HF_HOME }}
+  HF_HUB_DISABLE_TELEMETRY: "1"
   HF_USER_ID: ${{ inputs.enable_hf_hub_tests && secrets.MODEL_HUB_ID || '' }}
   HF_AUTH_TOKEN: ${{ inputs.enable_hf_hub_tests && secrets.MODEL_HUB_ACCESS || '' }}
 
@@ -141,6 +142,13 @@ jobs:
         run: |
           uv pip install --extra-index-url ${{ secrets.DEV_PKG_URL }} rebel-compiler==${{ inputs.rebel_compiler_version }}
 
+      - name: Warm HF model cache
+        if: steps.should_skip.outputs.skip != 'true'
+        run: |
+          # Download any test-referenced repo missing from the shared HF cache;
+          # the test run below is fully offline (HF_HUB_OFFLINE=1).
+          uv run --no-sync python .github/scripts/warm_hf_cache.py
+
       - name: Prepare artifact paths
         run: |
           ensure_dir() {
@@ -157,6 +165,10 @@ jobs:
         if: steps.should_skip.outputs.skip != 'true'
         env:
           OPTIMUM_RBLN_TEST_LEVEL: ${{ inputs.test_level }}
+          # The cache is warmed above, so tests never call the Hub API (the
+          # rate limit is shared account-wide with the other repos' CIs).
+          # Hub push/pull tests are the exception and need the network.
+          HF_HUB_OFFLINE: ${{ inputs.enable_hf_hub_tests && '0' || '1' }}
         run: |
           EXTRA_PYTEST_ARGS=""
           if [ "${{ inputs.save_artifacts_path }}" != "" ]; then


### PR DESCRIPTION
## What
Mitigation for the HF rate-limit incident (option 2: CI-level two-phase). Alternative to #685 — only one of the two should be adopted.

1. **Warm step** (`.github/scripts/warm_hf_cache.py`): extracts every hub repo id referenced by `tests/` and `test_cli.py` via AST scan, and runs `snapshot_download` only for repos missing from the cache. In steady state this step makes zero network calls too.
2. **Test run**: executes with `HF_HUB_OFFLINE=1`, so the suite makes **zero** Hub API calls. Stays online only when `enable_hf_hub_tests` is set (push/pull hub tests).
3. Also adds `HF_HUB_DISABLE_TELEMETRY=1`.

## Why
Even with a warm cache, `from_pretrained` fires an etag HEAD request per resolved file, which drains the account-wide rate limit shared with the vllm-rbln and compiler CIs (estimated at hundreds to ~1k requests per PR CI run).

## Details
- Pinned revisions supported: a class's `HF_MODEL_ID` is paired with any 40-hex `revision` literal in the same class body, and that revision is warmed.
- Cache check: a pinned repo needs `snapshots/<rev>` to exist; an unpinned repo needs the snapshot pointed to by `refs/main`, so a partially-cached repo is not misjudged.
- False positives (e.g. the `dummy/mistral` placeholder) are denylisted; a warming failure only logs a warning and never fails the build (if a test actually needs that repo, it fails offline with a clear error).
- PRs adding a new model need no extra steps — the warm step downloads it automatically.

## Verification
- Local dry-run: all 63 candidates resolve to real repos, 4 pinned revisions matched, 0 missing against the local cache
- `ruff check` / `ruff format` pass, workflow YAML parses

## Caveats
- Indirectly referenced repos (checkpoints downloaded inside library code, e.g. guardrails) are not picked up by the scan, but they already live in the shared cache so they work offline. A brand-new indirect reference would need a scan extension or an explicit entry.
- A fresh warm-up downloads the full snapshot, so a repo carrying both .bin and .safetensors pulls redundant files (one-time cost, amortized by the shared cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)