### PR TITLE
model(llava): revert #676 merged to main out-of-band

### DIFF
--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -386,8 +386,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
             image_features = projected_features[:, :num_real_patches, :]
         else:
             projector_out_size = [
-                # pixel_values is (num_images, channels, height, width).
-                pixel_values.shape[0],
+                pixel_values.shape[0] * pixel_values.shape[1],
                 (self.config.vision_config.image_size // self.config.vision_config.patch_size) ** 2,
                 self.config.text_config.hidden_size,
             ]


### PR DESCRIPTION
## Why

#676 (`7265279`) was squash-merged directly to **main**, bypassing the dev → main flow (main should only advance via dev sync merges, e.g. #661). This revert restores main to the last sync point.

- After this revert, main's tree is **byte-identical** to `88ea973` (verified: same tree hash `ac1f436`).
- The fix itself is correct and is re-landed on dev via a follow-up PR (linked below), so it flows to main through the normal next dev → main sync. Verified locally that the future sync merges cleanly and the fix survives.

## ⚠️ Merge-order constraint

Merge this **before** the next dev → main sync. If a sync containing the re-landed fix reaches main first, **close this PR instead of merging it** — merging it after the sync would silently remove the fix from main and later syncs would not restore it (verified locally).

Re-landing PR: will be linked in a comment.