### PR TITLE
model(llava): size the projector buffer by images, not images x channels

### DIFF
--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -396,7 +396,8 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
             image_features = projected_features[:, :num_real_patches, :]
         else:
             projector_out_size = [
-                pixel_values.shape[0] * pixel_values.shape[1],
+                # pixel_values is (num_images, channels, height, width).
+                pixel_values.shape[0],
                 (self.config.vision_config.image_size // self.config.vision_config.patch_size) ** 2,
                 self.config.text_config.hidden_size,
             ]


### PR DESCRIPTION
## What

Re-lands #676 on **dev**, where it should have been merged in the first place. #676 was accidentally squash-merged to main; #692 reverts it there.

This is a verbatim `cherry-pick -x 726527990` of the original squash commit — same patch (verified identical `git patch-id`), applied cleanly on top of dev's current `modeling_llava.py`.

## Original context (#676)

Serving `llava-hf/llava-1.5-7b-hf` fails on the first image request with a 576-vs-1728 placeholder/embedding mismatch. `get_image_features` sized the projector output buffer with `pixel_values.shape[0] * pixel_values.shape[1]`, but for LLaVA-1.5 `pixel_values` is 4-D `(num_images, channels, H, W)` — dim 1 is the RGB channel count, so the buffer was 3x too large. The expression is the LLaVA-NeXT (5-D) shape carried over into the 4-D path. Fix: use `pixel_values.shape[0]`, matching `vision_out_size` in the same function.

Verified on RBLN-CA22 via the documented vLLM recipe and locally via rbln_model_zoo inference (see #676 for details).

## Merge order

Merge #692 (revert on main) and this PR **before** the next dev → main sync. Verified locally: the subsequent sync merges without conflict and the fix survives on main.
