### PR TITLE
model(decoderonly): stop dropping logits_to_keep=0

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -247,7 +247,9 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         if phases is not None:
             self.validate_phases_type(phases)
         self.phases = phases or self._default_phases
-        self.logits_to_keep = logits_to_keep or self._default_logits_to_keep
+        # 0 is a meaningful value here (keep every position's logits), so it must not
+        # fall through to the class default the way an unset `None` does.
+        self.logits_to_keep = logits_to_keep if logits_to_keep is not None else self._default_logits_to_keep
         if self.logits_to_keep is not None and self.logits_to_keep > 1:
             raise NotImplementedError("`logits_to_keep` > 1 is currently not supported for RBLN models.")
 

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -247,8 +247,6 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         if phases is not None:
             self.validate_phases_type(phases)
         self.phases = phases or self._default_phases
-        # 0 is a meaningful value here (keep every position's logits), so it must not
-        # fall through to the class default the way an unset `None` does.
         self.logits_to_keep = logits_to_keep if logits_to_keep is not None else self._default_logits_to_keep
         if self.logits_to_keep is not None and self.logits_to_keep > 1:
             raise NotImplementedError("`logits_to_keep` > 1 is currently not supported for RBLN models.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,12 +218,6 @@ def test_submodule_config_object():
 
 
 def test_logits_to_keep_zero_survives_construction_and_reload(tmp_path):
-    """`logits_to_keep=0` asks the prefill graph for every position's logits, and 0 is falsy.
-
-    It used to collapse to the class default on both paths, so a CausalLM could not request
-    all-position logits at all, and a config saved with 0 came back as 1 -- leaving the
-    runtime passing `query_position` to a graph compiled without that input.
-    """
     cfg = RBLNLlamaForCausalLMConfig(logits_to_keep=0)
     assert cfg.logits_to_keep == 0
 
@@ -231,7 +225,6 @@ def test_logits_to_keep_zero_survives_construction_and_reload(tmp_path):
     cfg.save(str(config_path))
     assert RBLNLlamaForCausalLMConfig.from_pretrained(str(config_path)).logits_to_keep == 0
 
-    # Leaving it unset still falls back to the per-class default.
     assert RBLNLlamaForCausalLMConfig().logits_to_keep == 1
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,6 +217,24 @@ def test_submodule_config_object():
     assert model.rbln_config.language_model.batch_size == 2
 
 
+def test_logits_to_keep_zero_survives_construction_and_reload(tmp_path):
+    """`logits_to_keep=0` asks the prefill graph for every position's logits, and 0 is falsy.
+
+    It used to collapse to the class default on both paths, so a CausalLM could not request
+    all-position logits at all, and a config saved with 0 came back as 1 -- leaving the
+    runtime passing `query_position` to a graph compiled without that input.
+    """
+    cfg = RBLNLlamaForCausalLMConfig(logits_to_keep=0)
+    assert cfg.logits_to_keep == 0
+
+    config_path = tmp_path / "rbln_config.json"
+    cfg.save(str(config_path))
+    assert RBLNLlamaForCausalLMConfig.from_pretrained(str(config_path)).logits_to_keep == 0
+
+    # Leaving it unset still falls back to the per-class default.
+    assert RBLNLlamaForCausalLMConfig().logits_to_keep == 1
+
+
 def test_num_devices_deprecated_alias():
     """`tensor_parallel_size` is the deprecated alias of `num_devices` and must still map through."""
     cfg = RBLNMistralForCausalLMConfig(num_devices=4)


### PR DESCRIPTION
## Type of Change

- [x] Bug fix

## Overview

`RBLNDecoderOnlyModelConfig` used `or` to resolve `logits_to_keep`:

```python
self.logits_to_keep = logits_to_keep or self._default_logits_to_keep
```

Because `0` is falsy, it was incorrectly replaced by the class default. This prevented requesting logits for all positions and caused saved configurations with `0` to reload as `1`.

The fallback now applies only when the value is `None`:

```python
self.logits_to_keep = logits_to_keep if logits_to_keep is not None else self._default_logits_to_keep
```

A regression test verifies that:

- `logits_to_keep=0` is preserved during construction.
- `0` survives a save/reload round trip.
- An unset value still uses the class default.

## Verification

- `tests/test_config.py`: 39 passed, 2 skipped
- `ruff format --check`: passed
- `ruff check`: passed