### PR TITLE
model(vlm): handle attention_mask=None in raw forward() calls

### DIFF
--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -547,6 +547,8 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
             input_ids,
             attention_mask,
@@ -753,6 +755,10 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:
+            if attention_mask is None:
+                attention_mask = torch.ones_like(input_ids)
+            if generate_idx is None:
+                generate_idx = attention_mask.sum(dim=-1, keepdim=True).int()
             inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
                 input_ids,
                 attention_mask,

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -433,6 +433,8 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
             input_ids,
             attention_mask,
@@ -636,6 +638,10 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:
+            if attention_mask is None:
+                attention_mask = torch.ones_like(input_ids)
+            if generate_idx is None:
+                generate_idx = attention_mask.sum(dim=-1, keepdim=True).int()
             inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
                 input_ids,
                 attention_mask,

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -725,6 +725,8 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
             input_ids,
             attention_mask,
@@ -907,6 +909,10 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         text_config = self.config.get_text_config()
         if cache_position is None:  # prefill
+            if attention_mask is None:
+                attention_mask = torch.ones_like(input_ids)
+            if generate_idx is None:
+                generate_idx = attention_mask.sum(dim=-1, keepdim=True).int()
             inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
                 input_ids,
                 attention_mask,

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -673,6 +673,8 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas, visual_pos_mask, deepstack_visual_embeds = (
             self._preprocess_prefill(
                 input_ids,
@@ -931,6 +933,10 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:
+            if attention_mask is None:
+                attention_mask = torch.ones_like(input_ids)
+            if generate_idx is None:
+                generate_idx = attention_mask.sum(dim=-1, keepdim=True).int()
             inputs_embeds, position_embed, rope_deltas, visual_pos_mask, deepstack_visual_embeds = (
                 self._preprocess_prefill(
                     input_ids,


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview

Added raw-call defaults at the `forward()` entry points of four Qwen VLMs (qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_5):

- `attention_mask=None` → `torch.ones_like(input_ids)` (HF semantics: no mask means every token is attended)
- `generate_idx=None` → `attention_mask.sum(dim=-1, keepdim=True).int()` (same default as `RBLNDecoderOnlyModelForCausalLM.forward`)

blip_2 / gemma4 / exaone4_5 already handle None and are unchanged.

## Motivation and Context

The Qwen VLM implementations index `attention_mask` (and `generate_idx`) without a None guard (`attention_mask[b_idx]`, `generate_idx[b_idx]`), assuming they are always provided. That assumption only holds on the `generate()` path, where `GenerationMixin._prepare_attention_mask_for_generation` synthesizes a mask.

Calling `forward()` directly bypasses that safety net and crashes with `TypeError: 'NoneType' object is not subscriptable`. Real occurrences:

- **Any pipeline that uses a Qwen model as its text encoder** (e.g. Cosmos-Predict2.5): calls raw forward without a mask, like `text_encoder(input_ids, output_hidden_states=True)` → crash. The original HF models accept this call (None means every token is attended; the causal mask is always applied inside the model), so this is a behavioral mismatch with upstream.
- **RBLNColQwen2**: explicitly allows `attention_mask=None` and passes it straight into the qwen2_vl backbone forward → a live, reproducible bug today.

The fix inserts the same defaults at the same points where HF handles None, and is a no-op for the existing `generate()` path where a mask is always supplied. Note that HF does the same: `get_rope_index` skips padding-stripping via an `if attention_mask is not None:` guard, and forward runs causal-only when no mask is given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
