### PR TITLE
other: override cosmos rope from diffusers

### DIFF
--- a/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
 import rebel
 import torch
 from diffusers import CosmosTransformer3DModel
+from diffusers.models.embeddings import Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.transformers.transformer_cosmos import (
     CosmosEmbedding,
@@ -29,6 +31,7 @@ from torchvision import transforms
 
 from ....configuration_utils import DEFAULT_COMPILED_MODEL_NAME, RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import np_cos, np_sin
 from ....utils.logging import get_logger
 from ...configurations import RBLNCosmosTransformer3DModelConfig
 
@@ -40,6 +43,50 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
+
+
+class RBLNCosmosRotaryPosEmbed(CosmosRotaryPosEmbed):
+    def forward(self, hidden_states: torch.Tensor, fps: int | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+        _, _, num_frames, height, width = hidden_states.shape
+        pe_size = [num_frames // self.patch_size[0], height // self.patch_size[1], width // self.patch_size[2]]
+
+        h_theta = 10000.0 * self.h_ntk_factor
+        w_theta = 10000.0 * self.w_ntk_factor
+        t_theta = 10000.0 * self.t_ntk_factor
+
+        seq = torch.arange(max(self.max_size), dtype=torch.float32)
+        dim_h_range = torch.arange(0, self.dim_h, 2, dtype=torch.float32)[: (self.dim_h // 2)] / self.dim_h
+        dim_w_range = torch.arange(0, self.dim_w, 2, dtype=torch.float32)[: (self.dim_w // 2)] / self.dim_w
+        dim_t_range = torch.arange(0, self.dim_t, 2, dtype=torch.float32)[: (self.dim_t // 2)] / self.dim_t
+        h_spatial_freqs = 1.0 / (h_theta**dim_h_range)
+        w_spatial_freqs = 1.0 / (w_theta**dim_w_range)
+        temporal_freqs = 1.0 / (t_theta**dim_t_range)
+
+        emb_h = torch.outer(seq[: pe_size[1]], h_spatial_freqs)[None, :, None, :].repeat(pe_size[0], 1, pe_size[2], 1)
+        emb_w = torch.outer(seq[: pe_size[2]], w_spatial_freqs)[None, None, :, :].repeat(pe_size[0], pe_size[1], 1, 1)
+        if fps is None:
+            emb_t = torch.outer(seq[: pe_size[0]], temporal_freqs)
+        else:
+            emb_t = torch.outer(seq[: pe_size[0]] / fps * self.base_fps, temporal_freqs)
+        emb_t = emb_t[:, None, None, :].repeat(1, pe_size[1], pe_size[2], 1)
+
+        freqs = torch.cat([emb_t, emb_h, emb_w] * 2, dim=-1).flatten(0, 2).float()
+        return np_cos(freqs), np_sin(freqs)
+
+
+class RBLNTimesteps(Timesteps):
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        half_dim = self.num_channels // 2
+        exponent = -math.log(10000) * torch.arange(half_dim, dtype=torch.float32)
+        exponent = exponent / (half_dim - self.downscale_freq_shift)
+        emb = self.scale * (timesteps[:, None].float() * torch.exp(exponent)[None, :])
+
+        emb = torch.cat([np_sin(emb), np_cos(emb)], dim=-1)
+        if self.flip_sin_to_cos:
+            emb = torch.cat([emb[:, half_dim:], emb[:, :half_dim]], dim=-1)
+        if self.num_channels % 2 == 1:
+            emb = torch.nn.functional.pad(emb, (0, 1, 0, 0))
+        return emb
 
 
 class CosmosTransformer3DModelWrapper(torch.nn.Module):
@@ -115,7 +162,7 @@ class RBLNCosmosTransformer3DModel(RBLNModel):
         patch_embed_in_channels = (
             self.config.in_channels + 1 if self.config.concat_padding_mask else self.config.in_channels
         )
-        self.rope = CosmosRotaryPosEmbed(
+        self.rope = RBLNCosmosRotaryPosEmbed(
             hidden_size=self.config.attention_head_dim,
             max_size=self.config.max_size,
             patch_size=self.config.patch_size,
@@ -136,6 +183,10 @@ class RBLNCosmosTransformer3DModel(RBLNModel):
         self.patch_embed.load_state_dict(artifacts["patch_embed"])
         self.patch_embed.to(self.rbln_config.dtype)
         self.time_embed = CosmosEmbedding(hidden_size, hidden_size)
+        time_proj = self.time_embed.time_proj
+        self.time_embed.time_proj = RBLNTimesteps(
+            time_proj.num_channels, time_proj.flip_sin_to_cos, time_proj.downscale_freq_shift, time_proj.scale
+        )
         self.time_embed.load_state_dict(artifacts["time_embed"])
         self.time_embed.to(self.rbln_config.dtype)
 

--- a/src/optimum/rbln/modeling_rope_utils.py
+++ b/src/optimum/rbln/modeling_rope_utils.py
@@ -33,7 +33,7 @@ import numpy as np
 import torch
 from transformers import PretrainedConfig
 
-from ..utils.logging import get_logger
+from .utils.logging import get_logger
 
 
 logger = get_logger(__name__)

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -19,8 +19,8 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig, PreTrainedModel
 
+from ....modeling_rope_utils import ROPE_INIT_FUNCTIONS, np_cos, np_sin
 from ....utils import logging
-from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, np_cos, np_sin
 from .configuration_lora import RBLNLoRAConfig
 from .lora_architecture import LoRALinear
 

--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -29,9 +29,9 @@ from transformers.models.exaone4_5.modeling_exaone4_5 import (
 
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
-from ...modeling_rope_utils import np_cos, np_sin, qwen_vit_rot_pos_ids
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
 from .configuration_exaone4_5 import (
     RBLNExaone4_5_ForConditionalGenerationConfig,

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -32,11 +32,11 @@ from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbeddi
 
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import np_cos, np_sin
 from ....utils.logging import get_logger
 from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowAttentionKVCacheMeta
 from ...modeling_attention_utils import validate_sliding_window
 from ...modeling_outputs import RBLNDecoderOnlyOutput
-from ...modeling_rope_utils import np_cos, np_sin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -36,9 +36,9 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
 
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
-from ...modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
 from .configuration_qwen2_5_vl import (
     RBLNQwen2_5_VisionTransformerPretrainedModelConfig,

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -36,9 +36,9 @@ from transformers.models.qwen2_vl.modeling_qwen2_vl import (
 
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import _validate_output_hidden_states
-from ...modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ..decoderonly.modeling_decoderonly import (
     RBLNDecoderOnlyModel,
     RBLNDecoderOnlyModelForCausalLM,

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -32,10 +32,10 @@ from transformers.models.qwen3_5.modeling_qwen3_5 import (
 
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils import logging
 from ...cache_utils import FullAttentionKVCacheMeta, LinearAttentionCacheMeta
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
-from ...modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
 from .configuration_qwen3_5 import (

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -35,9 +35,9 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
 
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
+from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
-from ...modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager, RBLNRuntimeModel
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
 from .configuration_qwen3_vl import (

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -27,7 +27,7 @@ from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
     Qwen3VLMoeVisionRotaryEmbedding,
 )
 
-from ...modeling_rope_utils import np_cos, np_sin
+from ....modeling_rope_utils import np_cos, np_sin
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager, RBLNRuntimeModel
 from ..qwen3_vl.modeling_qwen3_vl import (
     RBLNQwen3VLForConditionalGeneration,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -712,7 +712,7 @@ class TestQwenRotaryLookup(unittest.TestCase):
             VisionRotaryEmbedding,
         )
 
-        from optimum.rbln.transformers.modeling_rope_utils import qwen_vit_rot_pos_ids
+        from optimum.rbln.modeling_rope_utils import qwen_vit_rot_pos_ids
 
         rot = VisionRotaryEmbedding(20)
         for merge in (1, 2, 4):
@@ -732,7 +732,7 @@ class TestQwenRotaryLookup(unittest.TestCase):
         from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig
         from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLTextRotaryEmbedding
 
-        from optimum.rbln.transformers.modeling_rope_utils import QwenMRopeLookupTable, build_qwen_mrope_lookup
+        from optimum.rbln.modeling_rope_utils import QwenMRopeLookupTable, build_qwen_mrope_lookup
 
         max_pos = 512
         standard = Qwen2VLRotaryEmbedding(


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

Following https://github.com/RBLN-SW/optimum-rbln/pull/672, override Cosmos classes from diffusers to use numpy cos & sin.


## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update