### PR TITLE
model(vlm): resolve text config for output_hidden_states buffers

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -452,8 +452,8 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
             int(torch.nonzero(attention_mask, as_tuple=False)[0][0].item()) if attention_mask is not None else 0
         )
 
+        text_config = self.config.get_text_config()
         if self.logits_last_dim is None:
-            text_config = self.config.get_text_config()
             logits_last_dim = text_config.vocab_size if self.rbln_config.can_generate else text_config.hidden_size
         else:
             logits_last_dim = self.logits_last_dim
@@ -480,11 +480,11 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
             hidden_states_size = (
                 1,
                 padded_mask_length,
-                self.config.hidden_size,
+                text_config.hidden_size,
             )
             output_hidden_states = [
                 torch.full(hidden_states_size, fill_value=1e-10, dtype=self.rbln_config.dtype)
-                for _ in range(self.config.num_hidden_layers + 1)
+                for _ in range(text_config.num_hidden_layers + 1)
             ]
 
             for i in range(padded_input_length // self.rbln_config.prefill_chunk_size):

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -592,7 +592,7 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
             )
             logits.append(output.logits)
             if self.rbln_config.output_hidden_states:
-                for l_idx in range(self.config.num_hidden_layers + 1):
+                for l_idx in range(self.config.text_config.num_hidden_layers + 1):
                     all_hidden_states[l_idx][b_idx].copy_(output.hidden_states[l_idx][0])
         logits = torch.cat(logits, dim=0)
 
@@ -793,7 +793,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
                 )
                 logits.append(output.logits)
                 if self.rbln_config.output_hidden_states:
-                    for l_idx in range(self.config.num_hidden_layers + 1):
+                    for l_idx in range(self.config.text_config.num_hidden_layers + 1):
                         all_hidden_states[l_idx][b_idx].copy_(output.hidden_states[l_idx][0])
             logits = torch.cat(logits, dim=0)
         # Decoder

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -861,6 +861,43 @@ class TestQwen2_5_VLForConditionalGeneration(LLMTest.TestLLM):
         assert not model.rbln_config.create_runtimes
 
 
+class TestQwen2_5_VLForConditionalGeneration_OutputHiddenStates(TestQwen2_5_VLForConditionalGeneration):
+    # Two prompts of different lengths: the shorter one is left-padded, exercising the
+    # padded-batch prefill output aggregation (hidden states must come back at full mask width
+    # and left-padded rows must not leak into the valid region).
+    PROMPTS = [
+        TestQwen2_5_VLForConditionalGeneration.PROMPT,
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>What is the main color of this image? Answer in one short sentence, please.<|im_end|>\n<|im_start|>assistant\n",
+    ]
+    HF_CONFIG_KWARGS = {}  # Initialize empty to avoid sharing with other classes
+    HF_CONFIG_KWARGS_PREPROCESSOR = {"max_pixels": 64 * 14 * 14, "padding_side": "left"}
+    RBLN_CLASS_KWARGS = {
+        "rbln_config": {
+            "visual": {"max_seq_len": 512},
+            "num_devices": 1,
+            "kvcache_partition_len": 16_384,
+            "max_seq_len": 32_768,
+            "batch_size": 2,
+            "output_hidden_states": True,
+        }
+    }
+
+    def get_inputs(self):
+        tokenizer = self.get_tokenizer()
+        img_path = f"{os.path.dirname(__file__)}/../assets/rbln_logo_light.png"
+        image = Image.open(img_path)
+        inputs = tokenizer(images=[image, image], text=self.PROMPTS, return_tensors="pt", padding=True)
+        inputs["max_new_tokens"] = 4
+        inputs["do_sample"] = False
+        return inputs
+
+    def test_generate(self):
+        self._test_output_hidden_states_generation()
+
+    def test_propagate_config(self):
+        self.skipTest("Covered by TestQwen2_5_VLForConditionalGeneration.")
+
+
 class TestQwen3VLForConditionalGeneration(LLMTest.TestLLM):
     RBLN_AUTO_CLASS = RBLNAutoModelForImageTextToText
     RBLN_CLASS = RBLNQwen3VLForConditionalGeneration


### PR DESCRIPTION
> **⚠️ Branch Target**: `dev`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview

- `RBLNRuntimeModel._prepare_prefill_outputs`: size the hidden-state output buffers via `self.config.get_text_config().hidden_size / num_hidden_layers` instead of flat `self.config.*` access. `get_text_config()` returns the config itself for plain LLMs, so this is a no-op for text-only models — and the same function was already used one branch above to resolve `logits_last_dim`.
- `RBLNQwen2_5_VLModel`: the hidden-state copy loops iterated `self.config.num_hidden_layers`; use `self.config.text_config.num_hidden_layers`, matching what the sibling implementations (qwen2_vl, qwen3_vl, qwen3_5) already do.
- Add `TestQwen2_5_VLForConditionalGeneration_OutputHiddenStates`, mirroring the existing qwen3_vl output_hidden_states test (batch of two left-padded prompts, `output_hidden_states=True`).

## Motivation and Context

transformers 5.x composite VLM configs (e.g. `Qwen2_5_VLConfig`) no longer expose text attributes like `hidden_size` / `num_hidden_layers` at the top level — they live in `config.text_config`. Two spots still assumed a flat config, so running Qwen2.5-VL with `output_hidden_states=True` crashed:

```
AttributeError: 'Qwen2_5_VLConfig' object has no attribute 'hidden_size'
```

The path was never exercised before: `generate()` does not request hidden states per forward step, and qwen3_vl sidesteps the runtime half by passing `config.text_config` into its runtime. Using a VLM as a text encoder — e.g. Cosmos-Predict2.5 calling `text_encoder(input_ids, output_hidden_states=True)` — hits both spots.

qwen2_5_vl had no output_hidden_states test (qwen3_vl does), so this PR adds one to cover the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
