### PR TITLE
other: nest submodule artifacts under the parent's subfolder

### DIFF
--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -176,6 +176,7 @@ class RBLNModel(RBLNBaseModel):
                 model_save_dir=save_dir,
                 rbln_config=rbln_config,
                 preprocessors=preprocessors,
+                parent_subfolder=subfolder,
                 **kwargs,
             )
         else:
@@ -191,7 +192,7 @@ class RBLNModel(RBLNBaseModel):
         )
 
         # Save compiled models (.rbln)
-        (save_dir_path / subfolder).mkdir(exist_ok=True)
+        (save_dir_path / subfolder).mkdir(parents=True, exist_ok=True)
         if not isinstance(compiled_model, dict):
             compiled_models = {DEFAULT_COMPILED_MODEL_NAME: compiled_model}
         else:

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -240,14 +240,9 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
                 if rbln_submodules is None:
                     # Resolve submodules relative to this model's own directory so that a nested
                     # parent (e.g. a VLM text_encoder inside a diffusers pipeline) finds them under
-                    # itself. Artifacts saved before the nested layout kept a nested parent's
-                    # submodules as siblings of the parent directory; legacy_save_dir lets those
-                    # still load.
+                    # itself.
                     rbln_submodules = cls._load_submodules(
-                        model_save_dir=model_path_subfolder,
-                        legacy_save_dir=str(Path(model_path_subfolder).parent) if subfolder else None,
-                        rbln_config=rbln_config,
-                        **kwargs,
+                        model_save_dir=model_path_subfolder, rbln_config=rbln_config, **kwargs
                     )
             elif rbln_submodules is None:
                 rbln_submodules = []

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -238,9 +238,6 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
 
             if len(cls._rbln_submodules) > 0:
                 if rbln_submodules is None:
-                    # Resolve submodules relative to this model's own directory so that a nested
-                    # parent (e.g. a VLM text_encoder inside a diffusers pipeline) finds them under
-                    # itself.
                     rbln_submodules = cls._load_submodules(
                         model_save_dir=model_path_subfolder, rbln_config=rbln_config, **kwargs
                     )

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -238,7 +238,17 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
 
             if len(cls._rbln_submodules) > 0:
                 if rbln_submodules is None:
-                    rbln_submodules = cls._load_submodules(model_save_dir=model_id, rbln_config=rbln_config, **kwargs)
+                    # Resolve submodules relative to this model's own directory so that a nested
+                    # parent (e.g. a VLM text_encoder inside a diffusers pipeline) finds them under
+                    # itself. Artifacts saved before the nested layout kept a nested parent's
+                    # submodules as siblings of the parent directory; legacy_save_dir lets those
+                    # still load.
+                    rbln_submodules = cls._load_submodules(
+                        model_save_dir=model_path_subfolder,
+                        legacy_save_dir=str(Path(model_path_subfolder).parent) if subfolder else None,
+                        rbln_config=rbln_config,
+                        **kwargs,
+                    )
             elif rbln_submodules is None:
                 rbln_submodules = []
 

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -164,7 +164,8 @@ class SubModulesMixin:
                 if legacy_json_file_path.exists():
                     logger.warning(
                         f"Loading submodule '{submodule_name}' from the pre-nested (sibling) layout "
-                        f"at {legacy_json_file_path.parent}. Re-saving this model migrates it to the "
+                        f"at {legacy_json_file_path.parent}. Support for this layout may be removed "
+                        "in a future release; recompile the model to produce an artifact in the "
                         "nested layout."
                     )
                     submodule_save_dir = submodule_save_dir.parent

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -164,8 +164,8 @@ class SubModulesMixin:
                 if legacy_json_file_path.exists():
                     logger.warning(
                         f"Loading submodule '{submodule_name}' from the pre-nested (sibling) layout "
-                        f"at {legacy_json_file_path.parent}. Support for this layout may be removed "
-                        "in a future release; recompile the model to produce an artifact in the "
+                        f"at {legacy_json_file_path.parent}. Support for this layout will be removed "
+                        "in v0.12.0; recompile the model to produce an artifact in the "
                         "nested layout."
                     )
                     submodule_save_dir = submodule_save_dir.parent

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Union
 from transformers import PretrainedConfig
 
 from ..configuration_utils import RBLNModelConfig, get_rbln_config_class
+from ..utils.logging import get_logger
 from ..utils.model_utils import get_rbln_model_cls
 
 
@@ -25,6 +26,9 @@ if TYPE_CHECKING:
     from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer, PreTrainedModel
 
     from ..modeling import RBLNModel
+
+
+logger = get_logger(__name__)
 
 
 class SubModulesMixin:
@@ -140,9 +144,6 @@ class SubModulesMixin:
     @classmethod
     def _load_submodules_from_compiled_models(cls, model_save_dir: str, rbln_config: RBLNModelConfig, **kwargs):
         rbln_submodules = []
-        # Artifacts saved before the nested layout kept a nested parent's submodules as
-        # SIBLINGS of the parent directory; fall back there when the nested path is absent.
-        legacy_save_dir = kwargs.pop("legacy_save_dir", None)
 
         for submodule in cls._rbln_submodules:
             submodule_name = submodule["name"]
@@ -153,17 +154,25 @@ class SubModulesMixin:
             # RBLNModelConfig -> RBLNModel
             submodule_cls = get_rbln_model_cls(submodule_rbln_config.rbln_model_cls_name)
 
-            submodule_save_dir = model_save_dir
-            json_file_path = Path(submodule_save_dir) / submodule_name / "config.json"
-            if not json_file_path.exists() and legacy_save_dir is not None:
-                legacy_json_file_path = Path(legacy_save_dir) / submodule_name / "config.json"
+            submodule_save_dir = Path(model_save_dir)
+            json_file_path = submodule_save_dir / submodule_name / "config.json"
+            if not json_file_path.exists():
+                # Artifacts saved before the nested submodule layout kept a nested parent's
+                # submodules as SIBLINGS of the parent directory; fall back there. Delete this
+                # block once that backward compatibility is dropped.
+                legacy_json_file_path = submodule_save_dir.parent / submodule_name / "config.json"
                 if legacy_json_file_path.exists():
-                    submodule_save_dir = legacy_save_dir
+                    logger.warning(
+                        f"Loading submodule '{submodule_name}' from the pre-nested (sibling) layout "
+                        f"at {legacy_json_file_path.parent}. Re-saving this model migrates it to the "
+                        "nested layout."
+                    )
+                    submodule_save_dir = submodule_save_dir.parent
                     json_file_path = legacy_json_file_path
             config = PretrainedConfig.from_json_file(json_file_path)
 
             rbln_submodule = submodule_cls._from_pretrained(
-                model_id=submodule_save_dir,
+                model_id=str(submodule_save_dir),
                 config=config,
                 subfolder=submodule_name,
                 rbln_config=submodule_rbln_config,

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -81,6 +81,11 @@ class SubModulesMixin:
         submodule_prefix = getattr(cls, "_rbln_submodule_prefix", None)
         submodule_postfix = getattr(cls, "_rbln_submodule_postfix", None)
         preprocessors = kwargs.pop("preprocessors", [])
+        # Nest submodule artifacts under the parent's subfolder so that a parent compiled
+        # with a non-empty subfolder (e.g. a VLM text_encoder inside a diffusers pipeline)
+        # keeps its submodules inside its own directory. This matches the load path, which
+        # resolves submodules relative to the parent's directory (model_path_subfolder).
+        parent_subfolder = kwargs.pop("parent_subfolder", "")
 
         for submodule in cls._rbln_submodules:
             submodule_name = submodule["name"]
@@ -126,7 +131,7 @@ class SubModulesMixin:
             rbln_submodule = submodule_cls.from_model(
                 model=torch_submodule,
                 config=torch_submodule.config,
-                subfolder=submodule_name,
+                subfolder=f"{parent_subfolder}/{submodule_name}" if parent_subfolder else submodule_name,
                 model_save_dir=model_save_dir,
                 rbln_config=submodule_rbln_config,
                 **kwargs,

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -158,8 +158,7 @@ class SubModulesMixin:
             json_file_path = submodule_save_dir / submodule_name / "config.json"
             if not json_file_path.exists():
                 # Artifacts saved before the nested submodule layout kept a nested parent's
-                # submodules as SIBLINGS of the parent directory; fall back there. Delete this
-                # block once that backward compatibility is dropped.
+                # submodules as siblings of the parent directory; fall back here.
                 legacy_json_file_path = submodule_save_dir.parent / submodule_name / "config.json"
                 if legacy_json_file_path.exists():
                     logger.warning(

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -81,10 +81,6 @@ class SubModulesMixin:
         submodule_prefix = getattr(cls, "_rbln_submodule_prefix", None)
         submodule_postfix = getattr(cls, "_rbln_submodule_postfix", None)
         preprocessors = kwargs.pop("preprocessors", [])
-        # Nest submodule artifacts under the parent's subfolder so that a parent compiled
-        # with a non-empty subfolder (e.g. a VLM text_encoder inside a diffusers pipeline)
-        # keeps its submodules inside its own directory. This matches the load path, which
-        # resolves submodules relative to the parent's directory (model_path_subfolder).
         parent_subfolder = kwargs.pop("parent_subfolder", "")
 
         for submodule in cls._rbln_submodules:

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -140,6 +140,9 @@ class SubModulesMixin:
     @classmethod
     def _load_submodules_from_compiled_models(cls, model_save_dir: str, rbln_config: RBLNModelConfig, **kwargs):
         rbln_submodules = []
+        # Artifacts saved before the nested layout kept a nested parent's submodules as
+        # SIBLINGS of the parent directory; fall back there when the nested path is absent.
+        legacy_save_dir = kwargs.pop("legacy_save_dir", None)
 
         for submodule in cls._rbln_submodules:
             submodule_name = submodule["name"]
@@ -150,11 +153,17 @@ class SubModulesMixin:
             # RBLNModelConfig -> RBLNModel
             submodule_cls = get_rbln_model_cls(submodule_rbln_config.rbln_model_cls_name)
 
-            json_file_path = Path(model_save_dir) / submodule_name / "config.json"
+            submodule_save_dir = model_save_dir
+            json_file_path = Path(submodule_save_dir) / submodule_name / "config.json"
+            if not json_file_path.exists() and legacy_save_dir is not None:
+                legacy_json_file_path = Path(legacy_save_dir) / submodule_name / "config.json"
+                if legacy_json_file_path.exists():
+                    submodule_save_dir = legacy_save_dir
+                    json_file_path = legacy_json_file_path
             config = PretrainedConfig.from_json_file(json_file_path)
 
             rbln_submodule = submodule_cls._from_pretrained(
-                model_id=model_save_dir,
+                model_id=submodule_save_dir,
                 config=config,
                 subfolder=submodule_name,
                 rbln_config=submodule_rbln_config,

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -158,7 +158,7 @@ class SubModulesMixin:
             json_file_path = submodule_save_dir / submodule_name / "config.json"
             if not json_file_path.exists():
                 # Artifacts saved before the nested submodule layout kept a nested parent's
-                # submodules as siblings of the parent directory; fall back here.
+                # submodules as siblings of the parent directory.
                 legacy_json_file_path = submodule_save_dir.parent / submodule_name / "config.json"
                 if legacy_json_file_path.exists():
                     logger.warning(


### PR DESCRIPTION
> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)

## Type of Change
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Overview

- **Save**: `RBLNModel.from_model` passes its own `subfolder` into `_load_submodules` as `parent_subfolder`; `_export_submodules_from_model` saves each submodule nested under it (`<parent_subfolder>/<submodule>`), with `mkdir(parents=True)`
- **Load**: submodules are resolved relative to the parent's own directory (`model_path_subfolder`) instead of the root `model_id`
- **Legacy fallback**: when the nested path is absent, loading falls back to the pre-change sibling location (`legacy_save_dir`), so artifacts saved before this change keep loading without recompilation

## Motivation and Context

Found with Cosmos-Predict2.5, whose text_encoder is a Qwen2.5-VL — the first VLM (a model that itself has a submodule) used as a diffusers pipeline submodule. Saving the pipeline silently dropped the VLM's `visual` artifacts, and loading failed with a missing `text_encoder/visual/config.json`. The walkthrough below uses ColPali (model → vlm → vision_tower / language_model) since it is the doubly-nested case that exists on `dev` and is covered by CI.

### SAVE — before

Compilation is a recursion of `from_model`; each level writes its artifacts to `<tmp>/<subfolder>/`. The old code set a child's subfolder to **its own name only**:

```
ColPali.from_model(subfolder="")
  └─ vlm.from_model(subfolder="vlm")
       ├─ vision_tower.from_model(subfolder="vision_tower")    # does not know its parent!
       └─ language_model.from_model(subfolder="language_model")

<tmp>/
├── (colpali files)
├── vlm/              # its children are NOT inside
├── vision_tower/     # vlm's child placed as a SIBLING
└── language_model/
```

`save_pretrained` then simply copies `<tmp>/<own subfolder>/`:

- **Top-level model (ColPali)**: subfolder is `""`, so the whole `<tmp>/` root is copied — the sibling-placed children come along by accident. It works, though the layout is misleading.
- **Parent that is itself a submodule (Cosmos text_encoder)**: diffusers calls `text_encoder.save_pretrained(<dst>/text_encoder)`, which copies only `<tmp>/text_encoder/` — the sibling `<tmp>/visual/` is copied by nobody and **vanishes with the temp directory**. This is the original bug.

### SAVE — after

`from_model` hands its own subfolder down to its children (`parent_subfolder`):

```
ColPali.from_model(subfolder="")
  └─ vlm.from_model(subfolder="vlm")
       ├─ vision_tower.from_model(subfolder="vlm/vision_tower")
       └─ language_model.from_model(subfolder="vlm/language_model")

<tmp>/
├── (colpali files)
└── vlm/
    ├── (vlm files)
    ├── vision_tower/      # now inside its owner
    └── language_model/
```

Whoever the saving party is, copying `<tmp>/<subfolder>/` now brings the children along, because they live inside it.

### LOAD — before

Loading is also a recursion, but the directory used to look up submodules was **fixed to the root `model_id` at every level**:

```
ColPali.from_pretrained(root)
  _load_submodules(model_save_dir = root)              # root
  vlm → root/vlm/config.json ✓
  └─ vlm._from_pretrained(model_id=root, subfolder="vlm")
       _load_submodules(model_save_dir = model_id = root)   # root again!
       vision_tower → root/vision_tower/config.json ✓       # the flat location
```

Flat save + flat load: a consistent world. (The first revision of this PR changed only the save side to nested, which is why the ColPali/ColQwen2 save/load round-trip broke in CI: it saved `root/vlm/vision_tower` but looked for `root/vision_tower`.)

### LOAD — after

The lookup base is each **parent's own directory** instead of the root:

```
ColPali.from_pretrained(root)
  own dir = root (subfolder="")
  _load_submodules(model_save_dir = root)
  vlm → root/vlm/config.json ✓
  └─ vlm._from_pretrained(model_id=root, subfolder="vlm")
       own dir = root/vlm
       _load_submodules(model_save_dir = root/vlm)     # look inside myself
       vision_tower → root/vlm/vision_tower/config.json ✓
```

### Legacy fallback

Artifacts saved before this change still have the flat layout, and the new load would not find their nested paths. When the nested path does not exist, the load falls back to where the old code would have put the submodule — the **parent of the current lookup directory** (`Path(model_save_dir).parent`), computed locally inside `_load_submodules_from_compiled_models` (no extra parameter threaded through the call chain):

```
vlm level, loading an OLD (flat) artifact:
  lookup dir = root/vlm
  vision_tower → root/vlm/vision_tower/config.json ✗
             → fallback: root/vision_tower/config.json ✓  (+ warning log)
             → _from_pretrained(model_id=root, subfolder="vision_tower")
                # byte-for-byte the same call the old load code made
```

Properties:
- New (nested) artifacts always hit the nested path; the legacy location is never consulted. If both exist, nested wins.
- Loading through the legacy location logs a warning, so migrations (and accidental hits) are visible.
- The fallback is one self-contained block in one function — dropping the backward compatibility later means deleting that block.
- It exists only on the load side. Note that re-saving does **not** migrate the layout (`save_pretrained` copies the existing tree as-is); recompiling is what produces a nested artifact — the warning says so.

| | save location | load looks in |
|---|---|---|
| before | always sibling (flat) | always root-based (flat) — consistent, but a nested parent loses its children on save |
| this PR, first revision | nested | root-based (flat) — **mismatched, broke CI** |
| final | nested | parent-based (nested), falling back to the old sibling location |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
