### PR TITLE
model(vlm): batch sort for flatten-patch VLM generate

### DIFF
--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -33,6 +33,7 @@ from ....modeling_rope_utils import np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_exaone4_5 import (
     RBLNExaone4_5_ForConditionalGenerationConfig,
     RBLNExaone4_5_VisionModelConfig,
@@ -57,6 +58,27 @@ def _disable_mtp(model_config):
         text_config._num_mtp_layers = 0
     if hasattr(text_config, "layer_types") and hasattr(text_config, "num_hidden_layers"):
         text_config.layer_types = text_config.layer_types[: text_config.num_hidden_layers]
+
+
+def _grid_rows_by_token_count(
+    input_ids: torch.Tensor, token_id: int, grid_thw: torch.Tensor | None, merge_unit: int
+) -> list[int]:
+    # grid row i yields prod(grid_thw[i]) // merge_unit placeholder tokens; walk the
+    # flattened rows in order, assigning them to samples by each row's token count
+    if grid_thw is None:
+        return [0] * input_ids.shape[0]
+    tokens_per_grid = (grid_thw.prod(dim=-1) // merge_unit).tolist()
+    rows, grid_idx = [], 0
+    for b_idx in range(input_ids.shape[0]):
+        needed = int((input_ids[b_idx] == token_id).sum().item())
+        start = grid_idx
+        while needed > 0:
+            if grid_idx >= len(tokens_per_grid) or tokens_per_grid[grid_idx] > needed:
+                raise ValueError("Vision grids do not align with per-sample vision token counts.")
+            needed -= tokens_per_grid[grid_idx]
+            grid_idx += 1
+        rows.append(grid_idx - start)
+    return rows
 
 
 class RBLNExaone4_5_VisionModel(RBLNModel):
@@ -466,7 +488,9 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
         )
 
 
-class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnlyModelForCausalLM):
+class RBLNExaone4_5_ForConditionalGeneration(
+    RBLNVisionBatchSortMixin, RBLNExaone4_5_Model, RBLNDecoderOnlyModelForCausalLM
+):
     """
     RBLNExaone4_5_ForConditionalGeneration is a multi-modal model that integrates vision and language
     processing capabilities, optimized for RBLN NPUs. It is designed for conditional generation tasks
@@ -482,6 +506,20 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
 
     def can_generate(self):
         return True
+
+    def _vision_grid_rows_per_sample(
+        self, input_ids: torch.LongTensor, attention_mask: torch.Tensor | None, kwargs: dict
+    ) -> tuple[list[int], list[int]]:
+        # no vision_start marker: _preprocess_prefill consumes grids in flattened order
+        # via masked_scatter, so per-sample ownership follows each row's token count
+        merge_unit = self.config.vision_config.spatial_merge_size**2
+        image_rows = _grid_rows_by_token_count(
+            input_ids, self.config.image_token_id, kwargs.get("image_grid_thw"), merge_unit
+        )
+        video_rows = _grid_rows_by_token_count(
+            input_ids, self.config.video_token_id, kwargs.get("video_grid_thw"), merge_unit
+        )
+        return image_rows, video_rows
 
     @classmethod
     def _reconstruct_model_if_needed(cls, model: "PreTrainedModel"):
@@ -499,6 +537,7 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
         image_grid_thw=None,
         video_grid_thw=None,
         second_per_grid_ts=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -527,6 +566,7 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
                 "image_grid_thw": image_grid_thw,
                 "video_grid_thw": video_grid_thw,
                 "second_per_grid_ts": second_per_grid_ts,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -545,8 +585,10 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
 
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -40,6 +40,7 @@ from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwe
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_qwen2_5_vl import (
     RBLNQwen2_5_VisionTransformerPretrainedModelConfig,
     RBLNQwen2_5_VLForConditionalGenerationConfig,
@@ -609,8 +610,10 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
             )
 
 
-# MRO: RBLNQwen2_5_VLForConditionalGeneration -> RBLNQwen2_5_VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
-class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnlyModelForCausalLM):
+# MRO: RBLNQwen2_5_VLForConditionalGeneration -> RBLNVisionBatchSortMixin -> RBLNQwen2_5_VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
+class RBLNQwen2_5_VLForConditionalGeneration(
+    RBLNVisionBatchSortMixin, RBLNQwen2_5_VLModel, RBLNDecoderOnlyModelForCausalLM
+):
     """
     RBLNQwen2_5_VLForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -676,6 +679,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
         video_grid_thw=None,
         second_per_grid_ts=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -706,6 +710,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
                 "video_grid_thw": video_grid_thw,
                 "second_per_grid_ts": second_per_grid_ts,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
 
@@ -750,8 +755,10 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -39,6 +39,7 @@ from ....modeling import RBLNModel
 from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import _validate_output_hidden_states
+from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin, _permute_flat_segments
 from ..decoderonly.modeling_decoderonly import (
     RBLNDecoderOnlyModel,
     RBLNDecoderOnlyModelForCausalLM,
@@ -60,6 +61,113 @@ if TYPE_CHECKING:
         AutoTokenizer,
         PretrainedConfig,
     )
+
+
+def _per_sample_patch_lens(grid_thw: torch.Tensor, rows_per_sample: list[int]) -> list[int]:
+    # patches for grid row i = t*h*w; sum rows owned by each sample
+    patches_per_row = grid_thw.prod(dim=-1).tolist()
+    lens, row_idx = [], 0
+    for n in rows_per_sample:
+        lens.append(sum(patches_per_row[row_idx : row_idx + n]))
+        row_idx += n
+    return lens
+
+
+class RBLNVisionBatchSortMixin:
+    # generate-entry batch sorting (use_batch_attn_opt) must carry the flattened vision
+    # inputs (patches / grid rows stacked on dim 0) along with their sample rows.
+    _video_grid_rows_are_chunks = False  # qwen3-style video grids are per temporal chunk
+    _generate_batch_sortable_kwargs = RBLNDecoderOnlyGenerationMixin._generate_batch_sortable_kwargs + (
+        "mm_token_type_ids",
+    )
+    _vision_sortable_keys = (
+        "pixel_values",
+        "pixel_values_videos",
+        "image_grid_thw",
+        "video_grid_thw",
+        "second_per_grid_ts",
+    )
+
+    def _sort_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict
+    ) -> tuple[torch.LongTensor | None, torch.Tensor | None]:
+        presort_input_ids = input_ids
+        presort_mask = kwargs.get("attention_mask")
+        input_ids, unsort_idx = super()._sort_generation_inputs(input_ids, kwargs)
+        if unsort_idx is None or not any(kwargs.get(k) is not None for k in self._vision_sortable_keys):
+            return input_ids, unsort_idx
+        if presort_input_ids is None:
+            raise RuntimeError("Batch sorting flattened vision inputs requires input_ids.")
+
+        # per-sample counts come from the pre-sort rows; segments are then permuted to match
+        sort_idx = torch.argsort(unsort_idx)
+        image_rows, video_rows = self._vision_grid_rows_per_sample(presort_input_ids, presort_mask, kwargs)
+        self._sort_vision_kwargs(kwargs, sort_idx, image_rows, video_rows)
+        return input_ids, unsort_idx
+
+    def _vision_grid_rows_per_sample(
+        self, input_ids: torch.LongTensor, attention_mask: torch.Tensor | None, kwargs: dict
+    ) -> tuple[list[int], list[int]]:
+        # same counting as _preprocess_prefill: vision_start marker followed by image/video token
+        image_rows, video_rows = [], []
+        video_grid_thw = kwargs.get("video_grid_thw")
+        video_row_idx = 0
+        for b_idx in range(input_ids.shape[0]):
+            row = input_ids[b_idx]
+            if attention_mask is not None:
+                row = row[attention_mask[b_idx].bool()]
+            vision_start_indices = torch.argwhere(row == self.config.vision_start_token_id).squeeze(1)
+            vision_tokens = row[vision_start_indices + 1]
+            image_rows.append(int((vision_tokens == self.config.image_token_id).sum().item()))
+            video_nums = int((vision_tokens == self.config.video_token_id).sum().item())
+            if self._video_grid_rows_are_chunks and video_grid_thw is not None:
+                start_row = video_row_idx
+                consumed_video_chunks = 0
+                while video_row_idx < video_grid_thw.shape[0] and consumed_video_chunks < video_nums:
+                    consumed_video_chunks += int(video_grid_thw[video_row_idx, 0].item())
+                    video_row_idx += 1
+                video_rows.append(video_row_idx - start_row)
+            else:
+                video_rows.append(video_nums)
+        return image_rows, video_rows
+
+    def _sort_vision_kwargs(
+        self, kwargs: dict, sort_idx: torch.Tensor, image_rows: list[int], video_rows: list[int]
+    ) -> None:
+        for grid_key, pixel_key, seg_rows in (
+            ("image_grid_thw", "pixel_values", image_rows),
+            ("video_grid_thw", "pixel_values_videos", video_rows),
+        ):
+            grid = kwargs.get(grid_key)
+            if grid is None:
+                continue
+            pixels = kwargs.get(pixel_key)
+            if pixels is not None:
+                kwargs[pixel_key] = _permute_flat_segments(pixels, _per_sample_patch_lens(grid, seg_rows), sort_idx)
+            kwargs[grid_key] = _permute_flat_segments(grid, seg_rows, sort_idx)
+
+        second_per_grid_ts = kwargs.get("second_per_grid_ts")
+        if second_per_grid_ts is not None:
+            if isinstance(second_per_grid_ts, torch.Tensor):
+                kwargs["second_per_grid_ts"] = _permute_flat_segments(second_per_grid_ts, video_rows, sort_idx)
+            else:
+                bounds = [0]
+                for n in video_rows:
+                    bounds.append(bounds[-1] + n)
+                kwargs["second_per_grid_ts"] = [
+                    v for i in sort_idx.tolist() for v in second_per_grid_ts[bounds[i] : bounds[i + 1]]
+                ]
+
+    def _check_batch_inputs_sorted(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
+        # this forward drives prefill_decoder per batch_idx itself, so the base forward's
+        # sorting fallback never runs; an unsorted direct call would silently mis-lay the KV cache
+        if inputs_sorted or batch_input is None or batch_input.shape[0] <= 1 or not self._batch_sort_enabled:
+            return
+        raise RuntimeError(
+            "use_batch_attn_opt requires batch inputs sorted by sequence length (descending). "
+            "Call generate(), which sorts and unsorts automatically, or pass `inputs_sorted=True` "
+            "with inputs (including flattened vision inputs) already sorted."
+        )
 
 
 class RBLNQwen2VisionTransformerPretrainedModel(RBLNModel):
@@ -496,8 +604,8 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
             )
 
 
-# MRO: RBLNQwen2VLForConditionalGeneration -> RBLNQwen2VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
-class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModelForCausalLM):
+# MRO: RBLNQwen2VLForConditionalGeneration -> RBLNVisionBatchSortMixin -> RBLNQwen2VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
+class RBLNQwen2VLForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen2VLModel, RBLNDecoderOnlyModelForCausalLM):
     """
     RBLNQwen2VLForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -561,6 +669,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
         image_grid_thw=None,
         video_grid_thw=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -590,6 +699,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
                 "image_grid_thw": image_grid_thw,
                 "video_grid_thw": video_grid_thw,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
 
@@ -633,8 +743,10 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -38,6 +38,7 @@ from ...cache_utils import FullAttentionKVCacheMeta, LinearAttentionCacheMeta
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_qwen3_5 import (
     RBLNQwen3_5ForConditionalGenerationConfig,  # noqa: F401
     RBLNQwen3_5ModelConfig,  # noqa: F401
@@ -771,7 +772,7 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         return RBLNDecoderOnlyOutput(logits=logits, hidden_states=all_hidden_states)
 
 
-class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModelForCausalLM):
+class RBLNQwen3_5ForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen3_5Model, RBLNDecoderOnlyModelForCausalLM):
     """
     RBLNQwen3_5ForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -809,6 +810,8 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         ```
     """
 
+    _video_grid_rows_are_chunks = True
+
     def __post_init__(self, **kwargs):
         super().__post_init__(**kwargs)
         self.rope_deltas = torch.zeros(self.rbln_config.batch_size)
@@ -836,6 +839,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         image_grid_thw=None,
         video_grid_thw=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -863,6 +867,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
                 "image_grid_thw": image_grid_thw,
                 "video_grid_thw": video_grid_thw,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -904,8 +909,10 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         return_dict: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
         output_hidden_states: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         text_config = self.config.get_text_config()
         if cache_position is None:  # prefill

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -39,7 +39,9 @@ from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwe
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager, RBLNRuntimeModel
+from ..decoderonly.generation_decoderonly import _permute_flat_segments
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin, _per_sample_patch_lens
 from .configuration_qwen3_vl import (
     RBLNQwen3VLForConditionalGenerationConfig,
     RBLNQwen3VLVisionModelConfig,
@@ -742,7 +744,7 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
             )
 
 
-class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModelForCausalLM):
+class RBLNQwen3VLForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen3VLModel, RBLNDecoderOnlyModelForCausalLM):
     """
     RBLNQwen3VLForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -783,6 +785,13 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
     _rbln_submodules = [
         {"name": "visual"},
     ]
+    _video_grid_rows_are_chunks = True
+    _vision_sortable_keys = RBLNVisionBatchSortMixin._vision_sortable_keys + (
+        "image_embeds",
+        "video_embeds",
+        "deepstack_image_embeds",
+        "deepstack_video_embeds",
+    )
 
     def __post_init__(self, **kwargs):
         super().__post_init__(**kwargs)
@@ -790,6 +799,28 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
 
     def can_generate(self):
         return True
+
+    def _sort_vision_kwargs(
+        self, kwargs: dict, sort_idx: torch.Tensor, image_rows: list[int], video_rows: list[int]
+    ) -> None:
+        # pre-computed encoder outputs (encoder-node path) are flattened in merged tokens;
+        # segment lengths must come from the grids before super() permutes them
+        merge_unit = self.config.vision_config.spatial_merge_size**2
+        for grid_key, embed_key, deepstack_key, seg_rows in (
+            ("image_grid_thw", "image_embeds", "deepstack_image_embeds", image_rows),
+            ("video_grid_thw", "video_embeds", "deepstack_video_embeds", video_rows),
+        ):
+            grid = kwargs.get(grid_key)
+            embeds = kwargs.get(embed_key)
+            deepstack_embeds = kwargs.get(deepstack_key)
+            if grid is None or (embeds is None and deepstack_embeds is None):
+                continue
+            token_lens = [n // merge_unit for n in _per_sample_patch_lens(grid, seg_rows)]
+            if embeds is not None:
+                kwargs[embed_key] = _permute_flat_segments(embeds, token_lens, sort_idx)
+            if deepstack_embeds is not None:
+                kwargs[deepstack_key] = [_permute_flat_segments(t, token_lens, sort_idx) for t in deepstack_embeds]
+        super()._sort_vision_kwargs(kwargs, sort_idx, image_rows, video_rows)
 
     @classmethod
     def _reconstruct_model_if_needed(cls, model: "PreTrainedModel"):
@@ -839,6 +870,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
         deepstack_image_embeds=None,
         deepstack_video_embeds=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -881,6 +913,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
                 "deepstack_image_embeds": deepstack_image_embeds,
                 "deepstack_video_embeds": deepstack_video_embeds,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
 
@@ -928,8 +961,10 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/tests/test_batch_sort_vlm_flatten.py
+++ b/tests/test_batch_sort_vlm_flatten.py
@@ -1,0 +1,234 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from optimum.rbln.transformers.models.decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
+from optimum.rbln.transformers.models.exaone4_5.modeling_exaone4_5 import RBLNExaone4_5_ForConditionalGeneration
+from optimum.rbln.transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import RBLNQwen2_5_VLForConditionalGeneration
+from optimum.rbln.transformers.models.qwen2_vl.modeling_qwen2_vl import (
+    RBLNQwen2VLForConditionalGeneration,
+    RBLNVisionBatchSortMixin,
+)
+from optimum.rbln.transformers.models.qwen3_vl.modeling_qwen3_vl import RBLNQwen3VLForConditionalGeneration
+
+
+VS, IMG, VID = 90, 91, 92
+
+
+def _make_model(cls, use_batch_attn_opt=True, **config_attrs):
+    model = object.__new__(cls)
+    model.rbln_config = SimpleNamespace(use_batch_attn_opt=use_batch_attn_opt)
+    model.config = SimpleNamespace(vision_start_token_id=VS, image_token_id=IMG, video_token_id=VID, **config_attrs)
+    return model
+
+
+def test_qwen2_vl_sort_vision_inputs():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration)
+    # lengths [4, 6, 5]; images per sample [2, 0, 1]; one video on sample 2
+    ids = torch.tensor(
+        [
+            [0, 0, VS, IMG, VS, IMG],
+            [1, 2, 3, 4, 5, 6],
+            [0, VS, IMG, VS, VID, 8],
+        ]
+    )
+    mask = torch.tensor([[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+    grids = torch.tensor([[1, 2, 2], [1, 2, 4], [1, 2, 6]])  # 4 + 8 patches (s0), 12 patches (s2)
+    pixels = torch.arange(24 * 3).reshape(24, 3)
+    video_grids = torch.tensor([[2, 2, 2]])
+    video_pixels = torch.arange(8 * 3).reshape(8, 3)
+
+    kwargs = {
+        "attention_mask": mask,
+        "pixel_values": pixels,
+        "image_grid_thw": grids,
+        "pixel_values_videos": video_pixels,
+        "video_grid_thw": video_grids,
+    }
+    sorted_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+
+    sort_idx = torch.tensor([1, 2, 0])  # lengths 6, 5, 4 descending
+    assert torch.equal(sorted_ids, ids.index_select(0, sort_idx))
+    assert torch.equal(kwargs["attention_mask"], mask.index_select(0, sort_idx))
+    assert kwargs["inputs_sorted"] is True
+    # image order becomes: (none from s1), s2's, then s0's two
+    assert torch.equal(kwargs["image_grid_thw"], grids[[2, 0, 1]])
+    assert torch.equal(kwargs["pixel_values"], torch.cat([pixels[12:24], pixels[0:12]]))
+    # single video: segments unchanged
+    assert torch.equal(kwargs["video_grid_thw"], video_grids)
+    assert torch.equal(kwargs["pixel_values_videos"], video_pixels)
+    # roundtrip restores original order
+    assert torch.equal(RBLNDecoderOnlyGenerationMixin._unsort_generation_outputs(sorted_ids, unsort_idx), ids)
+
+
+def test_qwen2_5_vl_videos_and_second_per_grid_ts():
+    model = _make_model(RBLNQwen2_5_VLForConditionalGeneration)
+    # lengths [4, 6, 5]; videos per sample [1, 0, 2]
+    ids = torch.tensor(
+        [
+            [0, 0, VS, VID, 7, 7],
+            [1, 2, 3, 4, 5, 6],
+            [0, VS, VID, VS, VID, 9],
+        ]
+    )
+    mask = torch.tensor([[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+    video_grids = torch.tensor([[1, 2, 2], [1, 2, 4], [2, 2, 2]])  # 4 (s0), 8 + 8 (s2)
+    video_pixels = torch.arange(20 * 2).reshape(20, 2)
+    ts = torch.tensor([0.1, 0.2, 0.3])
+
+    kwargs = {
+        "attention_mask": mask,
+        "pixel_values_videos": video_pixels,
+        "video_grid_thw": video_grids,
+        "second_per_grid_ts": ts,
+    }
+    sorted_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+
+    sort_idx = torch.tensor([1, 2, 0])
+    assert torch.equal(sorted_ids, ids.index_select(0, sort_idx))
+    assert torch.equal(kwargs["video_grid_thw"], video_grids[[1, 2, 0]])
+    assert torch.equal(kwargs["pixel_values_videos"], torch.cat([video_pixels[4:20], video_pixels[0:4]]))
+    assert torch.equal(kwargs["second_per_grid_ts"], torch.tensor([0.2, 0.3, 0.1]))
+    assert torch.equal(RBLNDecoderOnlyGenerationMixin._unsort_generation_outputs(sorted_ids, unsort_idx), ids)
+
+
+def test_qwen2_5_vl_second_per_grid_ts_list():
+    model = _make_model(RBLNQwen2_5_VLForConditionalGeneration)
+    ids = torch.tensor([[0, 0, VS, VID, 7, 7], [1, 2, 3, 4, 5, 6], [0, VS, VID, VS, VID, 9]])
+    mask = torch.tensor([[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+    kwargs = {
+        "attention_mask": mask,
+        "video_grid_thw": torch.tensor([[1, 2, 2], [1, 2, 4], [2, 2, 2]]),
+        "second_per_grid_ts": [0.1, 0.2, 0.3],
+    }
+    model._sort_generation_inputs(ids, kwargs)
+    assert kwargs["second_per_grid_ts"] == [0.2, 0.3, 0.1]
+
+
+def test_qwen3_vl_chunked_video_grid_rows():
+    model = _make_model(RBLNQwen3VLForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # sample 0: one video split into 2 temporal chunks (2 markers, one grid row with t=2)
+    # sample 1: one video with 1 chunk
+    ids = torch.tensor([[0, VS, VID, VS, VID, 7], [1, 2, 3, VS, VID, 6]])
+    mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    video_grids = torch.tensor([[2, 2, 2], [1, 2, 2]])  # 8 patches (s0), 4 patches (s1)
+    video_pixels = torch.arange(12 * 2).reshape(12, 2)
+
+    kwargs = {"attention_mask": mask, "pixel_values_videos": video_pixels, "video_grid_thw": video_grids}
+    sorted_ids, _ = model._sort_generation_inputs(ids, kwargs)
+
+    assert torch.equal(sorted_ids, ids.index_select(0, torch.tensor([1, 0])))
+    assert torch.equal(kwargs["video_grid_thw"], video_grids[[1, 0]])
+    assert torch.equal(kwargs["pixel_values_videos"], torch.cat([video_pixels[8:12], video_pixels[0:8]]))
+
+
+def test_qwen3_vl_precomputed_embeds():
+    model = _make_model(RBLNQwen3VLForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # images per sample [1, 1]; merged tokens = patches // 4: 2 (s0), 4 (s1)
+    ids = torch.tensor([[0, VS, IMG, 5, 5, 5], [VS, IMG, 3, 4, 5, 6]])
+    mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    grids = torch.tensor([[1, 2, 4], [1, 4, 4]])
+    embeds = torch.arange(6 * 2).reshape(6, 2).float()
+    deepstack = [embeds * 10, embeds * 100]
+
+    kwargs = {
+        "attention_mask": mask,
+        "image_grid_thw": grids,
+        "image_embeds": embeds,
+        "deepstack_image_embeds": deepstack,
+    }
+    model._sort_generation_inputs(ids, kwargs)
+
+    assert torch.equal(kwargs["image_grid_thw"], grids[[1, 0]])
+    assert torch.equal(kwargs["image_embeds"], torch.cat([embeds[2:6], embeds[0:2]]))
+    for scale, layer in zip((10, 100), kwargs["deepstack_image_embeds"], strict=True):
+        assert torch.equal(layer, torch.cat([embeds[2:6], embeds[0:2]]) * scale)
+
+
+def test_qwen3_vl_moe_inherits_mixin():
+    from optimum.rbln.transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
+        RBLNQwen3VLMoeForConditionalGeneration,
+    )
+
+    assert issubclass(RBLNQwen3VLMoeForConditionalGeneration, RBLNVisionBatchSortMixin)
+    assert RBLNQwen3VLMoeForConditionalGeneration._video_grid_rows_are_chunks is True
+
+
+def test_qwen3_5_inherits_mixin():
+    from optimum.rbln.transformers.models.qwen3_5.modeling_qwen3_5 import RBLNQwen3_5ForConditionalGeneration
+
+    assert issubclass(RBLNQwen3_5ForConditionalGeneration, RBLNVisionBatchSortMixin)
+    assert RBLNQwen3_5ForConditionalGeneration._video_grid_rows_are_chunks is True
+
+
+def test_exaone4_5_token_count_rows():
+    model = _make_model(RBLNExaone4_5_ForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # no vision_start marker; merged tokens per grid: 1, 2 (sample 0) and 4 (sample 2)
+    ids = torch.tensor(
+        [
+            [0, 0, 0, IMG, IMG, IMG, 5],
+            [1, 2, 3, 4, 5, 6, 7],
+            [0, IMG, IMG, IMG, IMG, 9, 9],
+        ]
+    )
+    mask = torch.tensor([[0, 0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1, 1]])
+    grids = torch.tensor([[1, 2, 2], [1, 2, 4], [1, 4, 4]])  # 4 + 8 patches (s0), 16 patches (s2)
+    pixels = torch.arange(28 * 3).reshape(28, 3)
+
+    kwargs = {"attention_mask": mask, "pixel_values": pixels, "image_grid_thw": grids}
+    sorted_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+
+    sort_idx = torch.tensor([1, 2, 0])  # lengths 7, 6, 4 descending
+    assert torch.equal(sorted_ids, ids.index_select(0, sort_idx))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(kwargs["image_grid_thw"], grids[[2, 0, 1]])
+    assert torch.equal(kwargs["pixel_values"], torch.cat([pixels[12:28], pixels[0:12]]))
+    assert torch.equal(RBLNDecoderOnlyGenerationMixin._unsort_generation_outputs(sorted_ids, unsort_idx), ids)
+
+
+def test_exaone4_5_misaligned_grids_raise():
+    model = _make_model(RBLNExaone4_5_ForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # sample 0 has 2 image tokens but the first grid yields 4 merged tokens
+    ids = torch.tensor([[IMG, IMG, 3, 4], [1, 2, 3, 4]])
+    kwargs = {"pixel_values": torch.zeros(16, 3), "image_grid_thw": torch.tensor([[1, 4, 4]])}
+    with pytest.raises(ValueError, match="do not align"):
+        model._sort_generation_inputs(ids, kwargs)
+
+
+def test_gate_off_noop():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration, use_batch_attn_opt=False)
+    ids = torch.tensor([[0, VS, IMG, 3], [1, 2, 3, 4]])
+    grids = torch.tensor([[1, 2, 2]])
+    pixels = torch.zeros(4, 3)
+    kwargs = {"pixel_values": pixels, "image_grid_thw": grids}
+    out_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+    assert out_ids is ids
+    assert unsort_idx is None
+    assert kwargs["pixel_values"] is pixels
+    assert kwargs["image_grid_thw"] is grids
+    assert "inputs_sorted" not in kwargs
+
+
+def test_check_batch_inputs_sorted_guard():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration)
+    batch = torch.zeros(2, 4, dtype=torch.long)
+    with pytest.raises(RuntimeError, match="sorted by sequence length"):
+        model._check_batch_inputs_sorted(batch, False)
+    model._check_batch_inputs_sorted(batch, True)
+    model._check_batch_inputs_sorted(batch[:1], False)
+    model._check_batch_inputs_sorted(None, False)
+
+    off = _make_model(RBLNQwen2VLForConditionalGeneration, use_batch_attn_opt=False)
+    off._check_batch_inputs_sorted(batch, False)
+
+
+def test_sort_requires_input_ids_for_vision():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration)
+    kwargs = {
+        "inputs_embeds": torch.zeros(2, 4, 8),
+        "pixel_values": torch.zeros(4, 3),
+        "image_grid_thw": torch.tensor([[1, 2, 2]]),
+    }
+    with pytest.raises(RuntimeError, match="requires input_ids"):
+        model._sort_generation_inputs(None, kwargs)


### PR DESCRIPTION
## What

Extends the batch-attn sort in `generate()` to the flatten-patch multimodal families (direct `RBLNDecoderOnlyModelForCausalLM` subclasses): **qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_vl_moe, qwen3_5, exaone4_5**.

## Why

These families' configs are `RBLNDecoderOnlyModelConfig` subclasses, so `use_batch_attn_opt` already exists and the base fast-path in `RBLNDecoderOnlyGenerationMixin.generate()` fires on CR13+. Without this PR it sorts `input_ids`/`attention_mask` by length while `pixel_values`, `grid_thw`, `second_per_grid_ts`, etc. stay in original order — the vision inputs are flattened across the batch on dim 0, so the base sort cannot see per-sample ownership. Result: **silent image/sample mis-pairing** for any multi-sample `generate()` on CR13+.

## How

`RBLNVisionBatchSortMixin` (in `qwen2_vl/modeling_qwen2_vl.py`, shared by all six families):
- overrides `_sort_generation_inputs`: after the base text sort, derives per-sample grid-row counts from the **pre-sort** `input_ids` rows and permutes each flattened tensor's segments with `_permute_flat_segments` and the same `sort_idx`
- counting reuses each family's `_preprocess_prefill` mechanism verbatim, so producer and consumer can never disagree
- `_check_batch_inputs_sorted` guard: these forwards drive `prefill_decoder` per `batch_idx` themselves and never reach the base forward's sorting fallback, so an unsorted direct multi-sample `forward()` call with the gate on now raises instead of silently mis-laying the KV cache. `inputs_sorted` is plumbed through each family's `prepare_inputs_for_generation` and `forward`. No-op when the gate is off.

## Per family

- **qwen2_vl**: vision_start-marker counting; images + videos.
- **qwen2_5_vl**: same, plus `second_per_grid_ts` (one entry per video grid row; tensor and list forms both handled).
- **qwen3_vl**: `_video_grid_rows_are_chunks = True` — video grid rows are temporal chunks, consumed by summing `t` per row exactly as its `_preprocess_prefill` does. Also permutes pre-computed `image_embeds`/`video_embeds`/`deepstack_*_embeds` from the encoder-node path (flattened in merged tokens, `patches // spatial_merge_size**2`); the default pixel_values path derives deepstack inside forward and needs no extra handling.
- **qwen3_vl_moe**: inherits everything from `RBLNQwen3VLForConditionalGeneration` (covered by a test asserting the inheritance and chunk flag).
- **qwen3_5**: qwen3-style chunked video grids; mixin added with `_video_grid_rows_are_chunks = True`.
- **exaone4_5**: no `vision_start_token_id` in its config — its `_preprocess_prefill` consumes grids purely via `masked_scatter` order. Per-sample ownership is derived by matching each row's placeholder-token count against merged-token counts per grid row (`prod(grid) // spatial_merge_size**2`), with a `ValueError` on misalignment.

Not verified on hardware: only host-side sorting logic is tested (no NPU/compile in the tests); end-to-end CR13 generate with real checkpoints has not been run in this PR.

Desired shared change (not made here to keep `models/decoderonly/` untouched): the mixin could live next to `RBLNDecoderOnlyGenerationMixin` in `decoderonly/generation_decoderonly.py`; it currently lives in `qwen2_vl` and is imported by the other families.

## Tests

`tests/test_batch_sort_vlm_flatten.py` (host-side, instances via `__new__` with fake configs): text sorted descending; grid/pixel segments follow their sample; videos + `second_per_grid_ts` (tensor and list); qwen3_vl chunked video rows and pre-computed embeds; exaone4_5 token-count matching and misalignment error; `inputs_sorted` set; `_unsort_generation_outputs` roundtrip; gate-off no-op; guard raise/no-raise. `tests/test_batch_attn_sort.py` still passes (24 passed total).

Stacked on #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)