### PR TITLE
model(vlm): batch sort for composition VLM generate

### DIFF
--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -25,9 +25,9 @@ from transformers.models.gemma3.modeling_gemma3 import Gemma3TextScaledWordEmbed
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ...modeling_outputs import RBLNDecoderOnlyOutput
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModelForCausalLM
 from .gemma3_architecture import Gemma3ForCausalLMWrapper
 from .gemma3_runtime_utils import RBLNGemma3RuntimeModel
@@ -74,12 +74,17 @@ class LoopProjector(LoopProcessor):
         return output[0]
 
 
-class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     auto_model_class = AutoModelForImageTextToText
     _rbln_submodules = [
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    _image_indexed_kwargs = ("pixel_values",)
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        return self.config.mm_tokens_per_image
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -273,8 +278,10 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         padded_cache_lengths: torch.Tensor | None = None,
         position_ids: torch.Tensor | None = None,
         output_hidden_states: bool | None = None,
+        inputs_sorted: bool = False,
         **lm_kwargs: dict[str, Any],
     ) -> tuple | RBLNDecoderOnlyOutput:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         output_hidden_states = (
             output_hidden_states
             if output_hidden_states is not None

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -37,9 +37,9 @@ from ....utils.logging import get_logger
 from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowAttentionKVCacheMeta
 from ...modeling_attention_utils import validate_sliding_window
 from ...modeling_outputs import RBLNDecoderOnlyOutput
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModelForCausalLM
 from .configuration_gemma4 import (
     DEFAULT_MAX_SOFT_TOKENS,
@@ -592,7 +592,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         return rbln_config
 
 
-class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     Gemma4 model for image-text-to-text generation optimized for RBLN NPU.
 
@@ -624,6 +624,28 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    _image_indexed_kwargs = ("pixel_values", "image_position_ids")
+    _generate_batch_sortable_kwargs = RBLNMultimodalBatchSortMixin._generate_batch_sortable_kwargs + (
+        "mm_token_type_ids",
+    )
+
+    def _sort_extra_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict, sort_idx: torch.Tensor
+    ) -> None:
+        super()._sort_extra_generation_inputs(input_ids, kwargs, sort_idx)
+        pixel_values_videos = kwargs.get("pixel_values_videos")
+        if isinstance(pixel_values_videos, torch.Tensor) and pixel_values_videos.shape[0] > 0:
+            # (num_videos, num_frames, ...): every frame is its own placeholder run
+            # (frames are separated by timestamp text, see the class docstring)
+            self._permute_segment_kwargs(
+                input_ids,
+                kwargs,
+                sort_idx,
+                ("pixel_values_videos", "video_position_ids"),
+                getattr(self.config, "video_token_id", None),
+                None,
+                runs_per_segment=pixel_values_videos.shape[1],
+            )
 
     @staticmethod
     def _reject_unsupported_modalities(
@@ -944,9 +966,11 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         video_position_ids: torch.Tensor | None = None,
         input_features: torch.Tensor | None = None,
         input_features_mask: torch.Tensor | None = None,
+        inputs_sorted: bool = False,
         **lm_kwargs: dict[str, Any],
     ) -> tuple | RBLNDecoderOnlyOutput:
         self._reject_unsupported_modalities(input_features, input_features_mask)
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
 
         output_hidden_states = (
             output_hidden_states

--- a/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
@@ -36,7 +36,7 @@ from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.runtime_utils import RBLNPytorchRuntime
 from ...modeling_outputs import RBLNDecoderOnlyOutput
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 
 
 if TYPE_CHECKING:
@@ -185,7 +185,7 @@ class RBLNIdefics3VisionTransformer(RBLNModel):
             return BaseModelOutput(last_hidden_state=last_hidden_state)
 
 
-class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNIdefics3ForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -227,6 +227,20 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     auto_model_class = AutoModelForImageTextToText
     _rbln_submodules = [{"name": "vision_model"}, {"name": "text_model"}]
     _rbln_submodule_prefix = "model"
+    _lm_attr_name = "text_model"
+    # pixel_values (B, num_images, C, H, W) and pixel_attention_mask (B, num_images, H, W) are batch-first
+    _generate_batch_sortable_kwargs = RBLNMultimodalBatchSortMixin._generate_batch_sortable_kwargs + (
+        "pixel_values",
+        "pixel_attention_mask",
+    )
+    # image_hidden_states is (num_images, seq, dim); each patch image is one placeholder run
+    _image_indexed_kwargs = ("image_hidden_states",)
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        # placeholder tokens per patch image, mirroring the connector output length
+        vision_config = self.config.vision_config
+        return (vision_config.image_size // vision_config.patch_size) ** 2 // self.config.scale_factor**2
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -309,6 +323,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
         pixel_attention_mask=None,
         image_hidden_states=None,
         generate_idx=None,
+        inputs_sorted=False,
         **kwargs,
     ):
         is_prefill_phase = generate_idx is None
@@ -348,6 +363,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
                 "image_hidden_states": image_hidden_states,
                 "cache_position": cache_position,
                 "generate_idx": generate_idx,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -465,8 +481,10 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
         cache_position: torch.Tensor = None,
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | Idefics3CausalLMOutputWithPast:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -27,8 +27,8 @@ from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 
 
 logger = get_logger(__name__)
@@ -112,7 +112,7 @@ class LoopProjector(LoopProcessor):
         return output[0]
 
 
-class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNLlavaForConditionalGeneration is a multi-modal model that combines vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -166,6 +166,12 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    # pixel_values is (num_images, C, H, W); image_sizes is (num_images, 2) for pixtral
+    _image_indexed_kwargs = ("pixel_values", "image_sizes")
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        return getattr(self.config, "image_seq_length", None)
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -264,6 +270,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         cache_position=None,
         image_sizes=None,
         generate_idx=None,
+        inputs_sorted=False,
         **kwargs,
     ):
         is_prefill_phase = generate_idx is None
@@ -300,6 +307,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
                 "pixel_values": pixel_values,
                 "cache_position": cache_position,
                 "generate_idx": generate_idx,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -464,8 +472,10 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         cache_position: torch.LongTensor | None = None,
         image_sizes: torch.Tensor | None = None,
         generate_idx: torch.Tensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | LlavaCausalLMOutputWithPast:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
@@ -37,8 +37,8 @@ from transformers.models.llava_next.modeling_llava_next import (
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyOutput
 
 
@@ -94,7 +94,7 @@ class LoopProjector(LoopProcessor):
         return output[0]
 
 
-class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNLlavaNextForConditionalGeneration is a multi-modal model that combines vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -130,6 +130,8 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    # pixel_values is (num_images, num_patches, C, H, W); image_sizes is (num_images, 2)
+    _image_indexed_kwargs = ("pixel_values", "image_sizes")
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -236,6 +238,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         cache_position=None,
         image_sizes=None,
         generate_idx=None,
+        inputs_sorted=False,
         **kwargs,
     ):
         is_prefill_phase = generate_idx is None
@@ -272,6 +275,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
                 "pixel_values": pixel_values,
                 "cache_position": cache_position,
                 "generate_idx": generate_idx,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -468,8 +472,10 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         cache_position: torch.Tensor = None,
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | RBLNDecoderOnlyOutput:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -33,8 +33,8 @@ from transformers.models.paligemma.modeling_paligemma import PaligemmaModelOutpu
 from ....configuration_utils import RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyOutput
 
 
@@ -62,7 +62,7 @@ class LoopVisionTower(LoopProcessor):
         )
 
 
-class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNPaliGemmaForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -93,6 +93,8 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    # one image per sample: pixel_values is batch-first (batch_size, C, H, W)
+    _generate_batch_sortable_kwargs = RBLNMultimodalBatchSortMixin._generate_batch_sortable_kwargs + ("pixel_values",)
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -320,8 +322,10 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         cache_position: torch.Tensor = None,
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | RBLNDecoderOnlyOutput:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/utils/generation_multimodal.py
+++ b/src/optimum/rbln/transformers/utils/generation_multimodal.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from ..models.decoderonly.generation_decoderonly import (
+    RBLNDecoderOnlyGenerationMixin,
+    _permute_flat_segments,
+)
+
+
+class RBLNMultimodalBatchSortMixin(RBLNDecoderOnlyGenerationMixin):
+    # Composition VLMs keep a plain RBLNModelConfig at the top level; the batched-attention
+    # contract (use_batch_attn_opt) lives on the inner language model's config.
+    _lm_attr_name = "language_model"
+    # generate kwargs stacked over images on dim 0, mapped to samples by placeholder-token
+    # order in input_ids; batch-first extras go in _generate_batch_sortable_kwargs instead.
+    _image_indexed_kwargs: tuple[str, ...] = ()
+
+    @property
+    def _batch_sort_enabled(self) -> bool:
+        language_model = getattr(self, self._lm_attr_name, None)
+        return bool(language_model is not None and getattr(language_model.rbln_config, "use_batch_attn_opt", None))
+
+    @property
+    def _image_token_id(self) -> int | None:
+        for name in ("image_token_id", "image_token_index"):
+            token_id = getattr(self.config, name, None)
+            if token_id is not None:
+                return token_id
+        return None
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        return None
+
+    def _sort_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict
+    ) -> tuple[torch.LongTensor | None, torch.Tensor | None]:
+        orig_input_ids = input_ids
+        input_ids, unsort_idx = super()._sort_generation_inputs(input_ids, kwargs)
+        if unsort_idx is not None:
+            self._sort_extra_generation_inputs(orig_input_ids, kwargs, torch.argsort(unsort_idx))
+        return input_ids, unsort_idx
+
+    def _sort_extra_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict, sort_idx: torch.Tensor
+    ) -> None:
+        self._permute_segment_kwargs(
+            input_ids, kwargs, sort_idx, self._image_indexed_kwargs, self._image_token_id, self._tokens_per_image
+        )
+
+    def _permute_segment_kwargs(
+        self,
+        input_ids: torch.LongTensor | None,
+        kwargs: dict,
+        sort_idx: torch.Tensor,
+        names: tuple[str, ...],
+        token_id: int | None,
+        tokens_per_segment: int | None,
+        runs_per_segment: int = 1,
+    ) -> None:
+        tensors = {
+            name: value for name in names if isinstance(value := kwargs.get(name), torch.Tensor) and value.shape[0] > 0
+        }
+        if not tensors:
+            return
+        num_segments = next(iter(tensors.values())).shape[0]
+        if any(value.shape[0] != num_segments for value in tensors.values()):
+            raise RuntimeError(
+                f"Image-indexed inputs {tuple(tensors)} disagree on the number of images; "
+                "cannot reorder them for batch-attention sorting."
+            )
+        seg_lens = self._segments_per_sample(input_ids, num_segments, token_id, tokens_per_segment, runs_per_segment)
+        for name, value in tensors.items():
+            kwargs[name] = _permute_flat_segments(value, seg_lens, sort_idx)
+
+    def _segments_per_sample(
+        self,
+        input_ids: torch.LongTensor | None,
+        num_segments: int,
+        token_id: int | None,
+        tokens_per_segment: int | None,
+        runs_per_segment: int,
+    ) -> list[int]:
+        # map dim-0-stacked segments (images/videos) back to batch rows through the
+        # placeholder tokens each sample carries
+        if input_ids is not None and token_id is not None:
+            is_placeholder = input_ids == token_id
+            # each image (or video frame) expands to one contiguous placeholder run
+            run_starts = is_placeholder.clone()
+            run_starts[:, 1:] &= ~is_placeholder[:, :-1]
+            run_counts = run_starts.sum(dim=1)
+            if int(run_counts.sum()) == num_segments * runs_per_segment and bool(
+                (run_counts % runs_per_segment == 0).all()
+            ):
+                return (run_counts // runs_per_segment).tolist()
+            # adjacent placeholders merge runs; fixed-size expansions can still split by token count
+            if tokens_per_segment:
+                token_counts = is_placeholder.sum(dim=1)
+                if int(token_counts.sum()) == num_segments * tokens_per_segment and bool(
+                    (token_counts % tokens_per_segment == 0).all()
+                ):
+                    return (token_counts // tokens_per_segment).tolist()
+        raise RuntimeError(
+            "Cannot map image inputs to batch samples for the sorting `use_batch_attn_opt` requires. "
+            "Pass inputs already sorted by sequence length (descending) with `inputs_sorted=True`."
+        )
+
+    def _require_sorted_batch_inputs(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
+        # the batched attention kernel reads a KV layout fixed by length-descending batch order;
+        # generate() establishes it once up front, a bare multi-batch forward() cannot
+        if inputs_sorted or not self._batch_sort_enabled:
+            return
+        if batch_input is not None and batch_input.shape[0] > 1:
+            raise RuntimeError(
+                "This model was compiled with `use_batch_attn_opt`, which requires batch inputs sorted by "
+                "sequence length (descending). Use generate(), which sorts and unsorts automatically, or "
+                "pass `inputs_sorted=True` with inputs already sorted."
+            )

--- a/tests/test_batch_sort_vlm_composition.py
+++ b/tests/test_batch_sort_vlm_composition.py
@@ -1,0 +1,234 @@
+import pytest
+import torch
+
+from optimum.rbln.transformers.models.gemma3.modeling_gemma3 import RBLNGemma3ForConditionalGeneration
+from optimum.rbln.transformers.models.gemma4.modeling_gemma4 import RBLNGemma4ForConditionalGeneration
+from optimum.rbln.transformers.models.idefics3.modeling_idefics3 import RBLNIdefics3ForConditionalGeneration
+from optimum.rbln.transformers.models.llava.modeling_llava import RBLNLlavaForConditionalGeneration
+from optimum.rbln.transformers.models.llava_next.modeling_llava_next import RBLNLlavaNextForConditionalGeneration
+from optimum.rbln.transformers.models.paligemma.modeling_paligemma import RBLNPaliGemmaForConditionalGeneration
+
+
+IMG = 99
+VID = 98
+
+
+def _fake_model(cls, config_fields, lm_attr="language_model", use_batch_attn_opt=True):
+    model = cls.__new__(cls)
+    lm_config = type("Cfg", (), {"use_batch_attn_opt": use_batch_attn_opt})()
+    setattr(model, lm_attr, type("LM", (), {"rbln_config": lm_config})())
+    model.config = type("Config", (), config_fields)()
+    return model
+
+
+def _images_by_sample(image_tensor, images_per_sample, order):
+    # expected image-first layout after permuting samples by `order`
+    segments = torch.split(image_tensor, images_per_sample, dim=0)
+    return torch.cat([segments[i] for i in order], dim=0)
+
+
+# lengths [4, 6, 5] -> descending sample order [1, 2, 0]
+MASK = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 0]])
+SORT = torch.tensor([1, 2, 0])
+
+
+def test_gemma3_sorts_flat_pixel_values():
+    model = _fake_model(RBLNGemma3ForConditionalGeneration, {"image_token_index": IMG, "mm_tokens_per_image": 2})
+    # images per sample: [1, 2, 0], each image = one run of 2 placeholder tokens
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, 3, IMG, IMG, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["attention_mask"], MASK.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_gemma3_gate_off_is_noop():
+    model = _fake_model(
+        RBLNGemma3ForConditionalGeneration,
+        {"image_token_index": IMG, "mm_tokens_per_image": 2},
+        use_batch_attn_opt=None,
+    )
+    input_ids = torch.tensor([[1, 2], [3, 4]])
+    kwargs = {"attention_mask": torch.tensor([[1, 1], [1, 0]]), "pixel_values": torch.zeros(2, 1, 1, 1)}
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+    assert sorted_ids is input_ids
+    assert unsort_idx is None
+    assert "inputs_sorted" not in kwargs
+
+
+def test_gemma3_batch_one_is_noop():
+    model = _fake_model(RBLNGemma3ForConditionalGeneration, {"image_token_index": IMG, "mm_tokens_per_image": 2})
+    input_ids = torch.tensor([[1, IMG, IMG]])
+    kwargs = {"pixel_values": torch.zeros(1, 1, 1, 1)}
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+    assert sorted_ids is input_ids
+    assert unsort_idx is None
+    assert "inputs_sorted" not in kwargs
+
+
+def test_gemma4_sorts_images_and_videos():
+    model = _fake_model(RBLNGemma4ForConditionalGeneration, {"image_token_id": IMG, "video_token_id": VID})
+    # images per sample [1, 0, 1]; one video (2 frames = 2 runs) on sample 1
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [VID, 3, VID, 4, 5, 6], [7, IMG, IMG, IMG, 8, 0]])
+    pixel_values = torch.arange(2, dtype=torch.float).view(2, 1, 1)
+    image_position_ids = torch.arange(2).view(2, 1)
+    pixel_values_videos = torch.arange(2, dtype=torch.float).view(1, 2, 1)
+    video_position_ids = torch.arange(2).view(1, 2, 1)
+    mm_token_type_ids = torch.arange(18).view(3, 6)
+    kwargs = {
+        "attention_mask": MASK.clone(),
+        "pixel_values": pixel_values,
+        "image_position_ids": image_position_ids,
+        "pixel_values_videos": pixel_values_videos,
+        "video_position_ids": video_position_ids,
+        "mm_token_type_ids": mm_token_type_ids,
+    }
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["mm_token_type_ids"], mm_token_type_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 0, 1], SORT.tolist()))
+    assert torch.equal(kwargs["image_position_ids"], _images_by_sample(image_position_ids, [1, 0, 1], SORT.tolist()))
+    # single video belongs to sample 1, which moves to row 0: layout unchanged
+    assert torch.equal(kwargs["pixel_values_videos"], pixel_values_videos)
+    assert torch.equal(kwargs["video_position_ids"], video_position_ids)
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_llava_run_counting_and_image_sizes():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": 2})
+    # images per sample [1, 2, 0] as separated runs
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, 3, IMG, IMG, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    image_sizes = torch.tensor([[8, 8], [16, 16], [32, 32]])
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values, "image_sizes": image_sizes}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+    assert torch.equal(kwargs["image_sizes"], _images_by_sample(image_sizes, [1, 2, 0], SORT.tolist()))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_llava_adjacent_images_fall_back_to_token_count():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": 2})
+    # sample 1 has two adjacent images (one merged run of 4 tokens)
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, IMG, IMG, 3, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values}
+
+    sorted_ids, _ = model._sort_generation_inputs(input_ids, kwargs)
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+
+
+def test_llava_unmappable_images_raise():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": None})
+    # 3 images but only 2 runs and no per-image token count to fall back on
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, IMG, IMG, 3, 4]])
+    kwargs = {
+        "attention_mask": torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 1, 1]]),
+        "pixel_values": torch.zeros(3, 1, 1, 1),
+    }
+    with pytest.raises(RuntimeError, match="Cannot map image inputs"):
+        model._sort_generation_inputs(input_ids, kwargs)
+
+
+def test_llava_next_sorts_patched_pixel_values():
+    model = _fake_model(RBLNLlavaNextForConditionalGeneration, {"image_token_index": IMG})
+    # variable-length runs per image; images per sample [1, 2, 0]
+    input_ids = torch.tensor([[1, IMG, IMG, IMG, 0, 0], [IMG, 2, IMG, IMG, 3, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(6, dtype=torch.float).view(3, 2, 1, 1, 1)
+    image_sizes = torch.tensor([[8, 8], [16, 16], [32, 32]])
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values, "image_sizes": image_sizes}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+    assert torch.equal(kwargs["image_sizes"], _images_by_sample(image_sizes, [1, 2, 0], SORT.tolist()))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_idefics3_sorts_batch_first_pixel_values():
+    vision_config = type("VisionCfg", (), {"image_size": 4, "patch_size": 2})()
+    model = _fake_model(
+        RBLNIdefics3ForConditionalGeneration,
+        {"image_token_id": IMG, "vision_config": vision_config, "scale_factor": 2},
+        lm_attr="text_model",
+    )
+    input_ids = torch.tensor([[1, IMG, 2, 0, 0, 0], [IMG, 3, IMG, 4, 5, 6], [7, 8, 9, 10, 11, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1, 1)
+    pixel_attention_mask = torch.arange(12).view(3, 1, 2, 2)
+    kwargs = {
+        "attention_mask": MASK.clone(),
+        "pixel_values": pixel_values,
+        "pixel_attention_mask": pixel_attention_mask,
+    }
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], pixel_values.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_attention_mask"], pixel_attention_mask.index_select(0, SORT))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_idefics3_sorts_image_hidden_states():
+    # (image_size // patch_size)**2 // scale_factor**2 = 1 placeholder token per patch image
+    vision_config = type("VisionCfg", (), {"image_size": 4, "patch_size": 2})()
+    model = _fake_model(
+        RBLNIdefics3ForConditionalGeneration,
+        {"image_token_id": IMG, "vision_config": vision_config, "scale_factor": 2},
+        lm_attr="text_model",
+    )
+    input_ids = torch.tensor([[1, IMG, 2, 0, 0, 0], [IMG, 3, IMG, 4, 5, 6], [7, 8, 9, 10, 11, 0]])
+    image_hidden_states = torch.arange(3, dtype=torch.float).view(3, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "image_hidden_states": image_hidden_states}
+
+    sorted_ids, _ = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["image_hidden_states"], _images_by_sample(image_hidden_states, [1, 2, 0], SORT.tolist()))
+
+
+def test_paligemma_sorts_batch_first_pixel_values():
+    model = _fake_model(RBLNPaliGemmaForConditionalGeneration, {"image_token_id": IMG})
+    input_ids = torch.tensor([[IMG, 1, 2, 0, 0, 0], [IMG, 3, 4, 5, 6, 7], [IMG, 8, 9, 10, 11, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], pixel_values.index_select(0, SORT))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_forward_guard_requires_sorted_inputs():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": 2})
+    batch_input = torch.zeros(2, 4, dtype=torch.long)
+    with pytest.raises(RuntimeError, match="use_batch_attn_opt"):
+        model._require_sorted_batch_inputs(batch_input, inputs_sorted=False)
+    model._require_sorted_batch_inputs(batch_input, inputs_sorted=True)
+    model._require_sorted_batch_inputs(batch_input[:1], inputs_sorted=False)
+
+    disabled = _fake_model(
+        RBLNLlavaForConditionalGeneration,
+        {"image_token_index": IMG, "image_seq_length": 2},
+        use_batch_attn_opt=None,
+    )
+    disabled._require_sorted_batch_inputs(batch_input, inputs_sorted=False)


### PR DESCRIPTION
## What

Wires batch-input sorting into the composition-style VLM families. On RBLN-CR13+, rebel-compiler routes mask-less flash attention to an in-memory batched kernel that requires batch inputs sorted by sequence length (descending). These families keep a plain `RBLNModelConfig` at the top level and drive the inner language model's `prefill_decoder`/`decoders[bs]` from their own `forward`, bypassing the base decoder-only forward — so sorting at `generate()` entry is their only path to the required batch order.

## How

New `transformers/utils/generation_multimodal.py` adds `RBLNMultimodalBatchSortMixin` (extends `RBLNDecoderOnlyGenerationMixin`):

- **Gate**: `_batch_sort_enabled` reads `use_batch_attn_opt` from the inner LM's config (`language_model.rbln_config`, or `text_model` via `_lm_attr_name`).
- **Image-first tensors**: `_image_indexed_kwargs` are stacked over images on dim 0. They are mapped back to batch rows by counting contiguous placeholder-token runs per row (each image is one run), with a fixed tokens-per-image fallback (`_tokens_per_image`) when adjacent images merge runs. This mirrors how each family's `_preprocess_prefill` scatters image features into rows via the placeholder mask. Unmappable layouts raise instead of silently permuting wrong.
- **Guard**: each family's `forward` accepts `inputs_sorted` (plumbed through `prepare_inputs_for_generation`) and raises for multi-batch unsorted calls while the gate is on, mirroring `_maybe_sort_inputs_for_batch_attn_opt`'s error style.

Everything is a no-op when the gate is off (CA targets, old configs, batch=1).

## Per family

- **gemma3**: `pixel_values` image-first; runs of `mm_tokens_per_image` placeholder tokens; token-count fallback covers adjacent images.
- **gemma4**: `pixel_values`/`image_position_ids` image-first; `mm_token_type_ids` batch-first (plain sortable kwarg). Videos: `pixel_values_videos`/`video_position_ids` are `(num_videos, num_frames, ...)`, mapped as `num_frames` placeholder runs per video (frames are separated by timestamp text per the class contract).
- **paligemma**: one image per sample, `pixel_values` batch-first → plain sortable kwarg.
- **llava**: `pixel_values`/`image_sizes` image-first; run counting, `image_seq_length` fallback. *Unverified edge*: pixtral-style checkpoints break each image's placeholder span into per-patch-row runs (`[IMG_BREAK]`), so a multi-image pixtral batch will typically fail the mapping and raise the explicit error (callers can pass pre-sorted inputs) rather than sort silently.
- **llava_next**: `pixel_values` `(num_images, num_patches, C, H, W)` and `image_sizes` `(num_images, 2)` image-first; anyres expansions are one contiguous run per image, variable length, so run counting only. A pre-flattened 4-dim `pixel_values` disagrees with `image_sizes` on dim 0 and raises rather than mis-permuting.
- **idefics3**: `pixel_values` `(B, num_images, ...)` and `pixel_attention_mask` batch-first → extended `_generate_batch_sortable_kwargs`. `image_hidden_states` (image-first, rare path) is mapped via runs with a config-derived tokens-per-patch fallback. Gate reads `self.text_model.rbln_config`.
- **blip2**: **no change needed** (verified by reading): its `generate` merges image features into batch-first `inputs_embeds` before delegating to `self.language_model.generate(...)`, so the inner LM mixin already sorts/unsorts everything, and image data travels with its row.

No files under `models/decoderonly/` were touched; no shared changes were needed.

## Tests

`tests/test_batch_sort_vlm_composition.py` (host-side, no NPU): per-family `_sort_generation_inputs` checks — descending text sort, image tensors following their sample, `inputs_sorted` set, unsort roundtrip, gate-off/batch-1 no-ops, unmappable-layout and unsorted-forward-guard errors. All 12 pass; `tests/test_batch_attn_sort.py` (12) still passes; ruff check/format clean.

Stacked on #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)