### PR TITLE
model(vlm): batch sort for multimodal generate

### DIFF
--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -32,8 +32,8 @@ from ....modeling import RBLNModel
 from ....modeling_rope_utils import np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
+from ...utils.generation_multimodal import RBLNVisionBatchSortMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
-from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_exaone4_5 import (
     RBLNExaone4_5_ForConditionalGenerationConfig,
     RBLNExaone4_5_VisionModelConfig,
@@ -588,7 +588,7 @@ class RBLNExaone4_5_ForConditionalGeneration(
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
-        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
+        self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
 
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -33,6 +33,7 @@ from ....modeling_rope_utils import np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_exaone4_5 import (
     RBLNExaone4_5_ForConditionalGenerationConfig,
     RBLNExaone4_5_VisionModelConfig,
@@ -57,6 +58,27 @@ def _disable_mtp(model_config):
         text_config._num_mtp_layers = 0
     if hasattr(text_config, "layer_types") and hasattr(text_config, "num_hidden_layers"):
         text_config.layer_types = text_config.layer_types[: text_config.num_hidden_layers]
+
+
+def _grid_rows_by_token_count(
+    input_ids: torch.Tensor, token_id: int, grid_thw: torch.Tensor | None, merge_unit: int
+) -> list[int]:
+    # grid row i yields prod(grid_thw[i]) // merge_unit placeholder tokens; walk the
+    # flattened rows in order, assigning them to samples by each row's token count
+    if grid_thw is None:
+        return [0] * input_ids.shape[0]
+    tokens_per_grid = (grid_thw.prod(dim=-1) // merge_unit).tolist()
+    rows, grid_idx = [], 0
+    for b_idx in range(input_ids.shape[0]):
+        needed = int((input_ids[b_idx] == token_id).sum().item())
+        start = grid_idx
+        while needed > 0:
+            if grid_idx >= len(tokens_per_grid) or tokens_per_grid[grid_idx] > needed:
+                raise ValueError("Vision grids do not align with per-sample vision token counts.")
+            needed -= tokens_per_grid[grid_idx]
+            grid_idx += 1
+        rows.append(grid_idx - start)
+    return rows
 
 
 class RBLNExaone4_5_VisionModel(RBLNModel):
@@ -466,7 +488,9 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
         )
 
 
-class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnlyModelForCausalLM):
+class RBLNExaone4_5_ForConditionalGeneration(
+    RBLNVisionBatchSortMixin, RBLNExaone4_5_Model, RBLNDecoderOnlyModelForCausalLM
+):
     """
     RBLNExaone4_5_ForConditionalGeneration is a multi-modal model that integrates vision and language
     processing capabilities, optimized for RBLN NPUs. It is designed for conditional generation tasks
@@ -482,6 +506,20 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
 
     def can_generate(self):
         return True
+
+    def _vision_grid_rows_per_sample(
+        self, input_ids: torch.LongTensor, attention_mask: torch.Tensor | None, kwargs: dict
+    ) -> tuple[list[int], list[int]]:
+        # no vision_start marker: _preprocess_prefill consumes grids in flattened order
+        # via masked_scatter, so per-sample ownership follows each row's token count
+        merge_unit = self.config.vision_config.spatial_merge_size**2
+        image_rows = _grid_rows_by_token_count(
+            input_ids, self.config.image_token_id, kwargs.get("image_grid_thw"), merge_unit
+        )
+        video_rows = _grid_rows_by_token_count(
+            input_ids, self.config.video_token_id, kwargs.get("video_grid_thw"), merge_unit
+        )
+        return image_rows, video_rows
 
     @classmethod
     def _reconstruct_model_if_needed(cls, model: "PreTrainedModel"):
@@ -499,6 +537,7 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
         image_grid_thw=None,
         video_grid_thw=None,
         second_per_grid_ts=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -527,6 +566,7 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
                 "image_grid_thw": image_grid_thw,
                 "video_grid_thw": video_grid_thw,
                 "second_per_grid_ts": second_per_grid_ts,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -545,8 +585,10 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
 
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -25,9 +25,9 @@ from transformers.models.gemma3.modeling_gemma3 import Gemma3TextScaledWordEmbed
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ...modeling_outputs import RBLNDecoderOnlyOutput
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModelForCausalLM
 from .gemma3_architecture import Gemma3ForCausalLMWrapper
 from .gemma3_runtime_utils import RBLNGemma3RuntimeModel
@@ -74,12 +74,17 @@ class LoopProjector(LoopProcessor):
         return output[0]
 
 
-class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     auto_model_class = AutoModelForImageTextToText
     _rbln_submodules = [
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    _image_indexed_kwargs = ("pixel_values",)
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        return self.config.mm_tokens_per_image
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -273,8 +278,10 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         padded_cache_lengths: torch.Tensor | None = None,
         position_ids: torch.Tensor | None = None,
         output_hidden_states: bool | None = None,
+        inputs_sorted: bool = False,
         **lm_kwargs: dict[str, Any],
     ) -> tuple | RBLNDecoderOnlyOutput:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         output_hidden_states = (
             output_hidden_states
             if output_hidden_states is not None

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -37,9 +37,9 @@ from ....utils.logging import get_logger
 from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowAttentionKVCacheMeta
 from ...modeling_attention_utils import validate_sliding_window
 from ...modeling_outputs import RBLNDecoderOnlyOutput
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModelForCausalLM
 from .configuration_gemma4 import (
     DEFAULT_MAX_SOFT_TOKENS,
@@ -592,7 +592,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         return rbln_config
 
 
-class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     Gemma4 model for image-text-to-text generation optimized for RBLN NPU.
 
@@ -624,6 +624,28 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    _image_indexed_kwargs = ("pixel_values", "image_position_ids")
+    _generate_batch_sortable_kwargs = RBLNMultimodalBatchSortMixin._generate_batch_sortable_kwargs + (
+        "mm_token_type_ids",
+    )
+
+    def _sort_extra_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict, sort_idx: torch.Tensor
+    ) -> None:
+        super()._sort_extra_generation_inputs(input_ids, kwargs, sort_idx)
+        pixel_values_videos = kwargs.get("pixel_values_videos")
+        if isinstance(pixel_values_videos, torch.Tensor) and pixel_values_videos.shape[0] > 0:
+            # (num_videos, num_frames, ...): every frame is its own placeholder run
+            # (frames are separated by timestamp text, see the class docstring)
+            self._permute_segment_kwargs(
+                input_ids,
+                kwargs,
+                sort_idx,
+                ("pixel_values_videos", "video_position_ids"),
+                getattr(self.config, "video_token_id", None),
+                None,
+                runs_per_segment=pixel_values_videos.shape[1],
+            )
 
     @staticmethod
     def _reject_unsupported_modalities(
@@ -944,9 +966,11 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         video_position_ids: torch.Tensor | None = None,
         input_features: torch.Tensor | None = None,
         input_features_mask: torch.Tensor | None = None,
+        inputs_sorted: bool = False,
         **lm_kwargs: dict[str, Any],
     ) -> tuple | RBLNDecoderOnlyOutput:
         self._reject_unsupported_modalities(input_features, input_features_mask)
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
 
         output_hidden_states = (
             output_hidden_states

--- a/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
@@ -36,7 +36,7 @@ from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.runtime_utils import RBLNPytorchRuntime
 from ...modeling_outputs import RBLNDecoderOnlyOutput
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 
 
 if TYPE_CHECKING:
@@ -185,7 +185,7 @@ class RBLNIdefics3VisionTransformer(RBLNModel):
             return BaseModelOutput(last_hidden_state=last_hidden_state)
 
 
-class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNIdefics3ForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -227,6 +227,20 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     auto_model_class = AutoModelForImageTextToText
     _rbln_submodules = [{"name": "vision_model"}, {"name": "text_model"}]
     _rbln_submodule_prefix = "model"
+    _lm_attr_name = "text_model"
+    # pixel_values (B, num_images, C, H, W) and pixel_attention_mask (B, num_images, H, W) are batch-first
+    _generate_batch_sortable_kwargs = RBLNMultimodalBatchSortMixin._generate_batch_sortable_kwargs + (
+        "pixel_values",
+        "pixel_attention_mask",
+    )
+    # image_hidden_states is (num_images, seq, dim); each patch image is one placeholder run
+    _image_indexed_kwargs = ("image_hidden_states",)
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        # placeholder tokens per patch image, mirroring the connector output length
+        vision_config = self.config.vision_config
+        return (vision_config.image_size // vision_config.patch_size) ** 2 // self.config.scale_factor**2
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -309,6 +323,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
         pixel_attention_mask=None,
         image_hidden_states=None,
         generate_idx=None,
+        inputs_sorted=False,
         **kwargs,
     ):
         is_prefill_phase = generate_idx is None
@@ -348,6 +363,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
                 "image_hidden_states": image_hidden_states,
                 "cache_position": cache_position,
                 "generate_idx": generate_idx,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -465,8 +481,10 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
         cache_position: torch.Tensor = None,
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | Idefics3CausalLMOutputWithPast:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -27,8 +27,8 @@ from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 
 
 logger = get_logger(__name__)
@@ -112,7 +112,7 @@ class LoopProjector(LoopProcessor):
         return output[0]
 
 
-class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNLlavaForConditionalGeneration is a multi-modal model that combines vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -166,6 +166,12 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    # pixel_values is (num_images, C, H, W); image_sizes is (num_images, 2) for pixtral
+    _image_indexed_kwargs = ("pixel_values", "image_sizes")
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        return getattr(self.config, "image_seq_length", None)
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -264,6 +270,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         cache_position=None,
         image_sizes=None,
         generate_idx=None,
+        inputs_sorted=False,
         **kwargs,
     ):
         is_prefill_phase = generate_idx is None
@@ -300,6 +307,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
                 "pixel_values": pixel_values,
                 "cache_position": cache_position,
                 "generate_idx": generate_idx,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -464,8 +472,10 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         cache_position: torch.LongTensor | None = None,
         image_sizes: torch.Tensor | None = None,
         generate_idx: torch.Tensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | LlavaCausalLMOutputWithPast:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
@@ -37,8 +37,8 @@ from transformers.models.llava_next.modeling_llava_next import (
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyOutput
 
 
@@ -94,7 +94,7 @@ class LoopProjector(LoopProcessor):
         return output[0]
 
 
-class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNLlavaNextForConditionalGeneration is a multi-modal model that combines vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -130,6 +130,8 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    # pixel_values is (num_images, num_patches, C, H, W); image_sizes is (num_images, 2)
+    _image_indexed_kwargs = ("pixel_values", "image_sizes")
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -236,6 +238,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         cache_position=None,
         image_sizes=None,
         generate_idx=None,
+        inputs_sorted=False,
         **kwargs,
     ):
         is_prefill_phase = generate_idx is None
@@ -272,6 +275,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
                 "pixel_values": pixel_values,
                 "cache_position": cache_position,
                 "generate_idx": generate_idx,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -468,8 +472,10 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         cache_position: torch.Tensor = None,
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | RBLNDecoderOnlyOutput:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -33,8 +33,8 @@ from transformers.models.paligemma.modeling_paligemma import PaligemmaModelOutpu
 from ....configuration_utils import RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
+from ...utils.generation_multimodal import RBLNMultimodalBatchSortMixin
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyOutput
 
 
@@ -62,7 +62,7 @@ class LoopVisionTower(LoopProcessor):
         )
 
 
-class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
+class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNMultimodalBatchSortMixin):
     """
     RBLNPaliGemmaForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -93,6 +93,8 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         {"name": "vision_tower"},
         {"name": "language_model"},
     ]
+    # one image per sample: pixel_values is batch-first (batch_size, C, H, W)
+    _generate_batch_sortable_kwargs = RBLNMultimodalBatchSortMixin._generate_batch_sortable_kwargs + ("pixel_values",)
 
     def __getattr__(self, __name: str) -> Any:
         def redirect(func):
@@ -320,8 +322,10 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         cache_position: torch.Tensor = None,
         generate_idx: torch.Tensor | None = None,
         return_dict: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | RBLNDecoderOnlyOutput:
+        self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -39,8 +39,8 @@ from ....modeling import RBLNModel
 from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
+from ...utils.generation_multimodal import RBLNVisionBatchSortMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
-from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_qwen2_5_vl import (
     RBLNQwen2_5_VisionTransformerPretrainedModelConfig,
     RBLNQwen2_5_VLForConditionalGenerationConfig,
@@ -758,7 +758,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
-        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
+        self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -40,6 +40,7 @@ from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwe
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_qwen2_5_vl import (
     RBLNQwen2_5_VisionTransformerPretrainedModelConfig,
     RBLNQwen2_5_VLForConditionalGenerationConfig,
@@ -609,8 +610,10 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
             )
 
 
-# MRO: RBLNQwen2_5_VLForConditionalGeneration -> RBLNQwen2_5_VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
-class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnlyModelForCausalLM):
+# MRO: RBLNQwen2_5_VLForConditionalGeneration -> RBLNVisionBatchSortMixin -> RBLNQwen2_5_VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
+class RBLNQwen2_5_VLForConditionalGeneration(
+    RBLNVisionBatchSortMixin, RBLNQwen2_5_VLModel, RBLNDecoderOnlyModelForCausalLM
+):
     """
     RBLNQwen2_5_VLForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -676,6 +679,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
         video_grid_thw=None,
         second_per_grid_ts=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -706,6 +710,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
                 "video_grid_thw": video_grid_thw,
                 "second_per_grid_ts": second_per_grid_ts,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
 
@@ -750,8 +755,10 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -39,6 +39,7 @@ from ....modeling import RBLNModel
 from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import _validate_output_hidden_states
+from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin, _permute_flat_segments
 from ..decoderonly.modeling_decoderonly import (
     RBLNDecoderOnlyModel,
     RBLNDecoderOnlyModelForCausalLM,
@@ -60,6 +61,113 @@ if TYPE_CHECKING:
         AutoTokenizer,
         PretrainedConfig,
     )
+
+
+def _per_sample_patch_lens(grid_thw: torch.Tensor, rows_per_sample: list[int]) -> list[int]:
+    # patches for grid row i = t*h*w; sum rows owned by each sample
+    patches_per_row = grid_thw.prod(dim=-1).tolist()
+    lens, row_idx = [], 0
+    for n in rows_per_sample:
+        lens.append(sum(patches_per_row[row_idx : row_idx + n]))
+        row_idx += n
+    return lens
+
+
+class RBLNVisionBatchSortMixin:
+    # generate-entry batch sorting (use_batch_attn_opt) must carry the flattened vision
+    # inputs (patches / grid rows stacked on dim 0) along with their sample rows.
+    _video_grid_rows_are_chunks = False  # qwen3-style video grids are per temporal chunk
+    _generate_batch_sortable_kwargs = RBLNDecoderOnlyGenerationMixin._generate_batch_sortable_kwargs + (
+        "mm_token_type_ids",
+    )
+    _vision_sortable_keys = (
+        "pixel_values",
+        "pixel_values_videos",
+        "image_grid_thw",
+        "video_grid_thw",
+        "second_per_grid_ts",
+    )
+
+    def _sort_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict
+    ) -> tuple[torch.LongTensor | None, torch.Tensor | None]:
+        presort_input_ids = input_ids
+        presort_mask = kwargs.get("attention_mask")
+        input_ids, unsort_idx = super()._sort_generation_inputs(input_ids, kwargs)
+        if unsort_idx is None or not any(kwargs.get(k) is not None for k in self._vision_sortable_keys):
+            return input_ids, unsort_idx
+        if presort_input_ids is None:
+            raise RuntimeError("Batch sorting flattened vision inputs requires input_ids.")
+
+        # per-sample counts come from the pre-sort rows; segments are then permuted to match
+        sort_idx = torch.argsort(unsort_idx)
+        image_rows, video_rows = self._vision_grid_rows_per_sample(presort_input_ids, presort_mask, kwargs)
+        self._sort_vision_kwargs(kwargs, sort_idx, image_rows, video_rows)
+        return input_ids, unsort_idx
+
+    def _vision_grid_rows_per_sample(
+        self, input_ids: torch.LongTensor, attention_mask: torch.Tensor | None, kwargs: dict
+    ) -> tuple[list[int], list[int]]:
+        # same counting as _preprocess_prefill: vision_start marker followed by image/video token
+        image_rows, video_rows = [], []
+        video_grid_thw = kwargs.get("video_grid_thw")
+        video_row_idx = 0
+        for b_idx in range(input_ids.shape[0]):
+            row = input_ids[b_idx]
+            if attention_mask is not None:
+                row = row[attention_mask[b_idx].bool()]
+            vision_start_indices = torch.argwhere(row == self.config.vision_start_token_id).squeeze(1)
+            vision_tokens = row[vision_start_indices + 1]
+            image_rows.append(int((vision_tokens == self.config.image_token_id).sum().item()))
+            video_nums = int((vision_tokens == self.config.video_token_id).sum().item())
+            if self._video_grid_rows_are_chunks and video_grid_thw is not None:
+                start_row = video_row_idx
+                consumed_video_chunks = 0
+                while video_row_idx < video_grid_thw.shape[0] and consumed_video_chunks < video_nums:
+                    consumed_video_chunks += int(video_grid_thw[video_row_idx, 0].item())
+                    video_row_idx += 1
+                video_rows.append(video_row_idx - start_row)
+            else:
+                video_rows.append(video_nums)
+        return image_rows, video_rows
+
+    def _sort_vision_kwargs(
+        self, kwargs: dict, sort_idx: torch.Tensor, image_rows: list[int], video_rows: list[int]
+    ) -> None:
+        for grid_key, pixel_key, seg_rows in (
+            ("image_grid_thw", "pixel_values", image_rows),
+            ("video_grid_thw", "pixel_values_videos", video_rows),
+        ):
+            grid = kwargs.get(grid_key)
+            if grid is None:
+                continue
+            pixels = kwargs.get(pixel_key)
+            if pixels is not None:
+                kwargs[pixel_key] = _permute_flat_segments(pixels, _per_sample_patch_lens(grid, seg_rows), sort_idx)
+            kwargs[grid_key] = _permute_flat_segments(grid, seg_rows, sort_idx)
+
+        second_per_grid_ts = kwargs.get("second_per_grid_ts")
+        if second_per_grid_ts is not None:
+            if isinstance(second_per_grid_ts, torch.Tensor):
+                kwargs["second_per_grid_ts"] = _permute_flat_segments(second_per_grid_ts, video_rows, sort_idx)
+            else:
+                bounds = [0]
+                for n in video_rows:
+                    bounds.append(bounds[-1] + n)
+                kwargs["second_per_grid_ts"] = [
+                    v for i in sort_idx.tolist() for v in second_per_grid_ts[bounds[i] : bounds[i + 1]]
+                ]
+
+    def _check_batch_inputs_sorted(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
+        # this forward drives prefill_decoder per batch_idx itself, so the base forward's
+        # sorting fallback never runs; an unsorted direct call would silently mis-lay the KV cache
+        if inputs_sorted or batch_input is None or batch_input.shape[0] <= 1 or not self._batch_sort_enabled:
+            return
+        raise RuntimeError(
+            "use_batch_attn_opt requires batch inputs sorted by sequence length (descending). "
+            "Call generate(), which sorts and unsorts automatically, or pass `inputs_sorted=True` "
+            "with inputs (including flattened vision inputs) already sorted."
+        )
 
 
 class RBLNQwen2VisionTransformerPretrainedModel(RBLNModel):
@@ -496,8 +604,8 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
             )
 
 
-# MRO: RBLNQwen2VLForConditionalGeneration -> RBLNQwen2VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
-class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModelForCausalLM):
+# MRO: RBLNQwen2VLForConditionalGeneration -> RBLNVisionBatchSortMixin -> RBLNQwen2VLModel -> RBLNDecoderOnlyModelForCausalLM -> RBLNDecoderOnlyModel -> RBLNModel
+class RBLNQwen2VLForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen2VLModel, RBLNDecoderOnlyModelForCausalLM):
     """
     RBLNQwen2VLForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -561,6 +669,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
         image_grid_thw=None,
         video_grid_thw=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -590,6 +699,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
                 "image_grid_thw": image_grid_thw,
                 "video_grid_thw": video_grid_thw,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
 
@@ -633,8 +743,10 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -39,7 +39,7 @@ from ....modeling import RBLNModel
 from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import _validate_output_hidden_states
-from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin, _permute_flat_segments
+from ...utils.generation_multimodal import RBLNVisionBatchSortMixin
 from ..decoderonly.modeling_decoderonly import (
     RBLNDecoderOnlyModel,
     RBLNDecoderOnlyModelForCausalLM,
@@ -61,113 +61,6 @@ if TYPE_CHECKING:
         AutoTokenizer,
         PretrainedConfig,
     )
-
-
-def _per_sample_patch_lens(grid_thw: torch.Tensor, rows_per_sample: list[int]) -> list[int]:
-    # patches for grid row i = t*h*w; sum rows owned by each sample
-    patches_per_row = grid_thw.prod(dim=-1).tolist()
-    lens, row_idx = [], 0
-    for n in rows_per_sample:
-        lens.append(sum(patches_per_row[row_idx : row_idx + n]))
-        row_idx += n
-    return lens
-
-
-class RBLNVisionBatchSortMixin:
-    # generate-entry batch sorting (use_batch_attn_opt) must carry the flattened vision
-    # inputs (patches / grid rows stacked on dim 0) along with their sample rows.
-    _video_grid_rows_are_chunks = False  # qwen3-style video grids are per temporal chunk
-    _generate_batch_sortable_kwargs = RBLNDecoderOnlyGenerationMixin._generate_batch_sortable_kwargs + (
-        "mm_token_type_ids",
-    )
-    _vision_sortable_keys = (
-        "pixel_values",
-        "pixel_values_videos",
-        "image_grid_thw",
-        "video_grid_thw",
-        "second_per_grid_ts",
-    )
-
-    def _sort_generation_inputs(
-        self, input_ids: torch.LongTensor | None, kwargs: dict
-    ) -> tuple[torch.LongTensor | None, torch.Tensor | None]:
-        presort_input_ids = input_ids
-        presort_mask = kwargs.get("attention_mask")
-        input_ids, unsort_idx = super()._sort_generation_inputs(input_ids, kwargs)
-        if unsort_idx is None or not any(kwargs.get(k) is not None for k in self._vision_sortable_keys):
-            return input_ids, unsort_idx
-        if presort_input_ids is None:
-            raise RuntimeError("Batch sorting flattened vision inputs requires input_ids.")
-
-        # per-sample counts come from the pre-sort rows; segments are then permuted to match
-        sort_idx = torch.argsort(unsort_idx)
-        image_rows, video_rows = self._vision_grid_rows_per_sample(presort_input_ids, presort_mask, kwargs)
-        self._sort_vision_kwargs(kwargs, sort_idx, image_rows, video_rows)
-        return input_ids, unsort_idx
-
-    def _vision_grid_rows_per_sample(
-        self, input_ids: torch.LongTensor, attention_mask: torch.Tensor | None, kwargs: dict
-    ) -> tuple[list[int], list[int]]:
-        # same counting as _preprocess_prefill: vision_start marker followed by image/video token
-        image_rows, video_rows = [], []
-        video_grid_thw = kwargs.get("video_grid_thw")
-        video_row_idx = 0
-        for b_idx in range(input_ids.shape[0]):
-            row = input_ids[b_idx]
-            if attention_mask is not None:
-                row = row[attention_mask[b_idx].bool()]
-            vision_start_indices = torch.argwhere(row == self.config.vision_start_token_id).squeeze(1)
-            vision_tokens = row[vision_start_indices + 1]
-            image_rows.append(int((vision_tokens == self.config.image_token_id).sum().item()))
-            video_nums = int((vision_tokens == self.config.video_token_id).sum().item())
-            if self._video_grid_rows_are_chunks and video_grid_thw is not None:
-                start_row = video_row_idx
-                consumed_video_chunks = 0
-                while video_row_idx < video_grid_thw.shape[0] and consumed_video_chunks < video_nums:
-                    consumed_video_chunks += int(video_grid_thw[video_row_idx, 0].item())
-                    video_row_idx += 1
-                video_rows.append(video_row_idx - start_row)
-            else:
-                video_rows.append(video_nums)
-        return image_rows, video_rows
-
-    def _sort_vision_kwargs(
-        self, kwargs: dict, sort_idx: torch.Tensor, image_rows: list[int], video_rows: list[int]
-    ) -> None:
-        for grid_key, pixel_key, seg_rows in (
-            ("image_grid_thw", "pixel_values", image_rows),
-            ("video_grid_thw", "pixel_values_videos", video_rows),
-        ):
-            grid = kwargs.get(grid_key)
-            if grid is None:
-                continue
-            pixels = kwargs.get(pixel_key)
-            if pixels is not None:
-                kwargs[pixel_key] = _permute_flat_segments(pixels, _per_sample_patch_lens(grid, seg_rows), sort_idx)
-            kwargs[grid_key] = _permute_flat_segments(grid, seg_rows, sort_idx)
-
-        second_per_grid_ts = kwargs.get("second_per_grid_ts")
-        if second_per_grid_ts is not None:
-            if isinstance(second_per_grid_ts, torch.Tensor):
-                kwargs["second_per_grid_ts"] = _permute_flat_segments(second_per_grid_ts, video_rows, sort_idx)
-            else:
-                bounds = [0]
-                for n in video_rows:
-                    bounds.append(bounds[-1] + n)
-                kwargs["second_per_grid_ts"] = [
-                    v for i in sort_idx.tolist() for v in second_per_grid_ts[bounds[i] : bounds[i + 1]]
-                ]
-
-    def _check_batch_inputs_sorted(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
-        # this forward drives prefill_decoder per batch_idx itself, so the base forward's
-        # sorting fallback never runs; an unsorted direct call would silently mis-lay the KV cache
-        if inputs_sorted or batch_input is None or batch_input.shape[0] <= 1 or not self._batch_sort_enabled:
-            return
-        raise RuntimeError(
-            "use_batch_attn_opt requires batch inputs sorted by sequence length (descending). "
-            "Call generate(), which sorts and unsorts automatically, or pass `inputs_sorted=True` "
-            "with inputs (including flattened vision inputs) already sorted."
-        )
 
 
 class RBLNQwen2VisionTransformerPretrainedModel(RBLNModel):
@@ -746,7 +639,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen2VLM
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
-        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
+        self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -36,9 +36,9 @@ from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwe
 from ....utils import logging
 from ...cache_utils import FullAttentionKVCacheMeta, LinearAttentionCacheMeta
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
+from ...utils.generation_multimodal import RBLNVisionBatchSortMixin
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
-from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_qwen3_5 import (
     RBLNQwen3_5ForConditionalGenerationConfig,  # noqa: F401
     RBLNQwen3_5ModelConfig,  # noqa: F401
@@ -912,7 +912,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen3_5M
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
-        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
+        self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         text_config = self.config.get_text_config()
         if cache_position is None:  # prefill

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -38,6 +38,7 @@ from ...cache_utils import FullAttentionKVCacheMeta, LinearAttentionCacheMeta
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin
 from .configuration_qwen3_5 import (
     RBLNQwen3_5ForConditionalGenerationConfig,  # noqa: F401
     RBLNQwen3_5ModelConfig,  # noqa: F401
@@ -771,7 +772,7 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         return RBLNDecoderOnlyOutput(logits=logits, hidden_states=all_hidden_states)
 
 
-class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModelForCausalLM):
+class RBLNQwen3_5ForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen3_5Model, RBLNDecoderOnlyModelForCausalLM):
     """
     RBLNQwen3_5ForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -809,6 +810,8 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         ```
     """
 
+    _video_grid_rows_are_chunks = True
+
     def __post_init__(self, **kwargs):
         super().__post_init__(**kwargs)
         self.rope_deltas = torch.zeros(self.rbln_config.batch_size)
@@ -836,6 +839,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         image_grid_thw=None,
         video_grid_thw=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -863,6 +867,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
                 "image_grid_thw": image_grid_thw,
                 "video_grid_thw": video_grid_thw,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
         return model_inputs
@@ -904,8 +909,10 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
         return_dict: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
         output_hidden_states: bool | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         text_config = self.config.get_text_config()
         if cache_position is None:  # prefill

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -39,7 +39,9 @@ from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwe
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager, RBLNRuntimeModel
+from ..decoderonly.generation_decoderonly import _permute_flat_segments
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
+from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin, _per_sample_patch_lens
 from .configuration_qwen3_vl import (
     RBLNQwen3VLForConditionalGenerationConfig,
     RBLNQwen3VLVisionModelConfig,
@@ -742,7 +744,7 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
             )
 
 
-class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModelForCausalLM):
+class RBLNQwen3VLForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen3VLModel, RBLNDecoderOnlyModelForCausalLM):
     """
     RBLNQwen3VLForConditionalGeneration is a multi-modal model that integrates vision and language processing capabilities,
     optimized for RBLN NPUs. It is designed for conditional generation tasks that involve both image and text inputs.
@@ -783,6 +785,13 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
     _rbln_submodules = [
         {"name": "visual"},
     ]
+    _video_grid_rows_are_chunks = True
+    _vision_sortable_keys = RBLNVisionBatchSortMixin._vision_sortable_keys + (
+        "image_embeds",
+        "video_embeds",
+        "deepstack_image_embeds",
+        "deepstack_video_embeds",
+    )
 
     def __post_init__(self, **kwargs):
         super().__post_init__(**kwargs)
@@ -790,6 +799,28 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
 
     def can_generate(self):
         return True
+
+    def _sort_vision_kwargs(
+        self, kwargs: dict, sort_idx: torch.Tensor, image_rows: list[int], video_rows: list[int]
+    ) -> None:
+        # pre-computed encoder outputs (encoder-node path) are flattened in merged tokens;
+        # segment lengths must come from the grids before super() permutes them
+        merge_unit = self.config.vision_config.spatial_merge_size**2
+        for grid_key, embed_key, deepstack_key, seg_rows in (
+            ("image_grid_thw", "image_embeds", "deepstack_image_embeds", image_rows),
+            ("video_grid_thw", "video_embeds", "deepstack_video_embeds", video_rows),
+        ):
+            grid = kwargs.get(grid_key)
+            embeds = kwargs.get(embed_key)
+            deepstack_embeds = kwargs.get(deepstack_key)
+            if grid is None or (embeds is None and deepstack_embeds is None):
+                continue
+            token_lens = [n // merge_unit for n in _per_sample_patch_lens(grid, seg_rows)]
+            if embeds is not None:
+                kwargs[embed_key] = _permute_flat_segments(embeds, token_lens, sort_idx)
+            if deepstack_embeds is not None:
+                kwargs[deepstack_key] = [_permute_flat_segments(t, token_lens, sort_idx) for t in deepstack_embeds]
+        super()._sort_vision_kwargs(kwargs, sort_idx, image_rows, video_rows)
 
     @classmethod
     def _reconstruct_model_if_needed(cls, model: "PreTrainedModel"):
@@ -839,6 +870,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
         deepstack_image_embeds=None,
         deepstack_video_embeds=None,
         mm_token_type_ids=None,
+        inputs_sorted: bool = False,
         **kwargs,
     ):
         model_inputs = {}
@@ -881,6 +913,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
                 "deepstack_image_embeds": deepstack_image_embeds,
                 "deepstack_video_embeds": deepstack_video_embeds,
                 "mm_token_type_ids": mm_token_type_ids,
+                "inputs_sorted": inputs_sorted,
             }
         )
 
@@ -928,8 +961,10 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
         return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         mm_token_type_ids: torch.IntTensor | None = None,
+        inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -38,10 +38,10 @@ from ....modeling import RBLNModel
 from ....modeling_rope_utils import build_qwen_mrope_lookup, np_cos, np_sin, qwen_vit_rot_pos_ids
 from ....utils.logging import get_logger
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
+from ...utils.generation_multimodal import RBLNVisionBatchSortMixin, _per_sample_patch_lens
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager, RBLNRuntimeModel
 from ..decoderonly.generation_decoderonly import _permute_flat_segments
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
-from ..qwen2_vl.modeling_qwen2_vl import RBLNVisionBatchSortMixin, _per_sample_patch_lens
 from .configuration_qwen3_vl import (
     RBLNQwen3VLForConditionalGenerationConfig,
     RBLNQwen3VLVisionModelConfig,
@@ -964,7 +964,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNVisionBatchSortMixin, RBLNQwen3VLM
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
-        self._check_batch_inputs_sorted(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
+        self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/utils/generation_multimodal.py
+++ b/src/optimum/rbln/transformers/utils/generation_multimodal.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from ..models.decoderonly.generation_decoderonly import (
+    RBLNDecoderOnlyGenerationMixin,
+    _permute_flat_segments,
+)
+
+
+class RBLNMultimodalBatchSortMixin(RBLNDecoderOnlyGenerationMixin):
+    # Composition VLMs keep a plain RBLNModelConfig at the top level; the batched-attention
+    # contract (use_batch_attn_opt) lives on the inner language model's config.
+    _lm_attr_name = "language_model"
+    # generate kwargs stacked over images on dim 0, mapped to samples by placeholder-token
+    # order in input_ids; batch-first extras go in _generate_batch_sortable_kwargs instead.
+    _image_indexed_kwargs: tuple[str, ...] = ()
+
+    @property
+    def _batch_sort_enabled(self) -> bool:
+        language_model = getattr(self, self._lm_attr_name, None)
+        return bool(language_model is not None and getattr(language_model.rbln_config, "use_batch_attn_opt", None))
+
+    @property
+    def _image_token_id(self) -> int | None:
+        for name in ("image_token_id", "image_token_index"):
+            token_id = getattr(self.config, name, None)
+            if token_id is not None:
+                return token_id
+        return None
+
+    @property
+    def _tokens_per_image(self) -> int | None:
+        return None
+
+    def _sort_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict
+    ) -> tuple[torch.LongTensor | None, torch.Tensor | None]:
+        orig_input_ids = input_ids
+        input_ids, unsort_idx = super()._sort_generation_inputs(input_ids, kwargs)
+        if unsort_idx is not None:
+            self._sort_extra_generation_inputs(orig_input_ids, kwargs, torch.argsort(unsort_idx))
+        return input_ids, unsort_idx
+
+    def _sort_extra_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict, sort_idx: torch.Tensor
+    ) -> None:
+        self._permute_segment_kwargs(
+            input_ids, kwargs, sort_idx, self._image_indexed_kwargs, self._image_token_id, self._tokens_per_image
+        )
+
+    def _permute_segment_kwargs(
+        self,
+        input_ids: torch.LongTensor | None,
+        kwargs: dict,
+        sort_idx: torch.Tensor,
+        names: tuple[str, ...],
+        token_id: int | None,
+        tokens_per_segment: int | None,
+        runs_per_segment: int = 1,
+    ) -> None:
+        tensors = {
+            name: value for name in names if isinstance(value := kwargs.get(name), torch.Tensor) and value.shape[0] > 0
+        }
+        if not tensors:
+            return
+        num_segments = next(iter(tensors.values())).shape[0]
+        if any(value.shape[0] != num_segments for value in tensors.values()):
+            raise RuntimeError(
+                f"Image-indexed inputs {tuple(tensors)} disagree on the number of images; "
+                "cannot reorder them for batch-attention sorting."
+            )
+        seg_lens = self._segments_per_sample(input_ids, num_segments, token_id, tokens_per_segment, runs_per_segment)
+        for name, value in tensors.items():
+            kwargs[name] = _permute_flat_segments(value, seg_lens, sort_idx)
+
+    def _segments_per_sample(
+        self,
+        input_ids: torch.LongTensor | None,
+        num_segments: int,
+        token_id: int | None,
+        tokens_per_segment: int | None,
+        runs_per_segment: int,
+    ) -> list[int]:
+        # map dim-0-stacked segments (images/videos) back to batch rows through the
+        # placeholder tokens each sample carries
+        if input_ids is not None and token_id is not None:
+            is_placeholder = input_ids == token_id
+            # each image (or video frame) expands to one contiguous placeholder run
+            run_starts = is_placeholder.clone()
+            run_starts[:, 1:] &= ~is_placeholder[:, :-1]
+            run_counts = run_starts.sum(dim=1)
+            if int(run_counts.sum()) == num_segments * runs_per_segment and bool(
+                (run_counts % runs_per_segment == 0).all()
+            ):
+                return (run_counts // runs_per_segment).tolist()
+            # adjacent placeholders merge runs; fixed-size expansions can still split by token count
+            if tokens_per_segment:
+                token_counts = is_placeholder.sum(dim=1)
+                if int(token_counts.sum()) == num_segments * tokens_per_segment and bool(
+                    (token_counts % tokens_per_segment == 0).all()
+                ):
+                    return (token_counts // tokens_per_segment).tolist()
+        raise RuntimeError(
+            "Cannot map image inputs to batch samples for the sorting `use_batch_attn_opt` requires. "
+            "Pass inputs already sorted by sequence length (descending) with `inputs_sorted=True`."
+        )
+
+    def _require_sorted_batch_inputs(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
+        # the batched attention kernel reads a KV layout fixed by length-descending batch order;
+        # generate() establishes it once up front, a bare multi-batch forward() cannot
+        if inputs_sorted or not self._batch_sort_enabled:
+            return
+        if batch_input is not None and batch_input.shape[0] > 1:
+            raise RuntimeError(
+                "This model was compiled with `use_batch_attn_opt`, which requires batch inputs sorted by "
+                "sequence length (descending). Use generate(), which sorts and unsorts automatically, or "
+                "pass `inputs_sorted=True` with inputs already sorted."
+            )

--- a/src/optimum/rbln/transformers/utils/generation_multimodal.py
+++ b/src/optimum/rbln/transformers/utils/generation_multimodal.py
@@ -20,7 +20,22 @@ from ..models.decoderonly.generation_decoderonly import (
 )
 
 
-class RBLNMultimodalBatchSortMixin(RBLNDecoderOnlyGenerationMixin):
+class RBLNBatchSortGuardMixin:
+    def _require_sorted_batch_inputs(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
+        # these forwards drive prefill_decoder/decoder themselves, so the base forward's
+        # sorting fallback never runs; an unsorted direct multi-batch call would silently
+        # mis-lay the KV cache
+        if inputs_sorted or not self._batch_sort_enabled:
+            return
+        if batch_input is not None and batch_input.shape[0] > 1:
+            raise RuntimeError(
+                "This model was compiled with `use_batch_attn_opt`, which requires batch inputs sorted by "
+                "sequence length (descending). Use generate(), which sorts and unsorts automatically, or "
+                "pass `inputs_sorted=True` with inputs already sorted."
+            )
+
+
+class RBLNMultimodalBatchSortMixin(RBLNBatchSortGuardMixin, RBLNDecoderOnlyGenerationMixin):
     # Composition VLMs keep a plain RBLNModelConfig at the top level; the batched-attention
     # contract (use_batch_attn_opt) lives on the inner language model's config.
     _lm_attr_name = "language_model"
@@ -118,14 +133,98 @@ class RBLNMultimodalBatchSortMixin(RBLNDecoderOnlyGenerationMixin):
             "Pass inputs already sorted by sequence length (descending) with `inputs_sorted=True`."
         )
 
-    def _require_sorted_batch_inputs(self, batch_input: torch.Tensor | None, inputs_sorted: bool) -> None:
-        # the batched attention kernel reads a KV layout fixed by length-descending batch order;
-        # generate() establishes it once up front, a bare multi-batch forward() cannot
-        if inputs_sorted or not self._batch_sort_enabled:
-            return
-        if batch_input is not None and batch_input.shape[0] > 1:
-            raise RuntimeError(
-                "This model was compiled with `use_batch_attn_opt`, which requires batch inputs sorted by "
-                "sequence length (descending). Use generate(), which sorts and unsorts automatically, or "
-                "pass `inputs_sorted=True` with inputs already sorted."
-            )
+
+def _per_sample_patch_lens(grid_thw: torch.Tensor, rows_per_sample: list[int]) -> list[int]:
+    # patches for grid row i = t*h*w; sum rows owned by each sample
+    patches_per_row = grid_thw.prod(dim=-1).tolist()
+    lens, row_idx = [], 0
+    for n in rows_per_sample:
+        lens.append(sum(patches_per_row[row_idx : row_idx + n]))
+        row_idx += n
+    return lens
+
+
+class RBLNVisionBatchSortMixin(RBLNBatchSortGuardMixin):
+    # generate-entry batch sorting (use_batch_attn_opt) must carry the flattened vision
+    # inputs (patches / grid rows stacked on dim 0) along with their sample rows.
+    _video_grid_rows_are_chunks = False  # qwen3-style video grids are per temporal chunk
+    _generate_batch_sortable_kwargs = RBLNDecoderOnlyGenerationMixin._generate_batch_sortable_kwargs + (
+        "mm_token_type_ids",
+    )
+    _vision_sortable_keys = (
+        "pixel_values",
+        "pixel_values_videos",
+        "image_grid_thw",
+        "video_grid_thw",
+        "second_per_grid_ts",
+    )
+
+    def _sort_generation_inputs(
+        self, input_ids: torch.LongTensor | None, kwargs: dict
+    ) -> tuple[torch.LongTensor | None, torch.Tensor | None]:
+        presort_input_ids = input_ids
+        presort_mask = kwargs.get("attention_mask")
+        input_ids, unsort_idx = super()._sort_generation_inputs(input_ids, kwargs)
+        if unsort_idx is None or not any(kwargs.get(k) is not None for k in self._vision_sortable_keys):
+            return input_ids, unsort_idx
+        if presort_input_ids is None:
+            raise RuntimeError("Batch sorting flattened vision inputs requires input_ids.")
+
+        # per-sample counts come from the pre-sort rows; segments are then permuted to match
+        sort_idx = torch.argsort(unsort_idx)
+        image_rows, video_rows = self._vision_grid_rows_per_sample(presort_input_ids, presort_mask, kwargs)
+        self._sort_vision_kwargs(kwargs, sort_idx, image_rows, video_rows)
+        return input_ids, unsort_idx
+
+    def _vision_grid_rows_per_sample(
+        self, input_ids: torch.LongTensor, attention_mask: torch.Tensor | None, kwargs: dict
+    ) -> tuple[list[int], list[int]]:
+        # same counting as _preprocess_prefill: vision_start marker followed by image/video token
+        image_rows, video_rows = [], []
+        video_grid_thw = kwargs.get("video_grid_thw")
+        video_row_idx = 0
+        for b_idx in range(input_ids.shape[0]):
+            row = input_ids[b_idx]
+            if attention_mask is not None:
+                row = row[attention_mask[b_idx].bool()]
+            vision_start_indices = torch.argwhere(row == self.config.vision_start_token_id).squeeze(1)
+            vision_tokens = row[vision_start_indices + 1]
+            image_rows.append(int((vision_tokens == self.config.image_token_id).sum().item()))
+            video_nums = int((vision_tokens == self.config.video_token_id).sum().item())
+            if self._video_grid_rows_are_chunks and video_grid_thw is not None:
+                start_row = video_row_idx
+                consumed_video_chunks = 0
+                while video_row_idx < video_grid_thw.shape[0] and consumed_video_chunks < video_nums:
+                    consumed_video_chunks += int(video_grid_thw[video_row_idx, 0].item())
+                    video_row_idx += 1
+                video_rows.append(video_row_idx - start_row)
+            else:
+                video_rows.append(video_nums)
+        return image_rows, video_rows
+
+    def _sort_vision_kwargs(
+        self, kwargs: dict, sort_idx: torch.Tensor, image_rows: list[int], video_rows: list[int]
+    ) -> None:
+        for grid_key, pixel_key, seg_rows in (
+            ("image_grid_thw", "pixel_values", image_rows),
+            ("video_grid_thw", "pixel_values_videos", video_rows),
+        ):
+            grid = kwargs.get(grid_key)
+            if grid is None:
+                continue
+            pixels = kwargs.get(pixel_key)
+            if pixels is not None:
+                kwargs[pixel_key] = _permute_flat_segments(pixels, _per_sample_patch_lens(grid, seg_rows), sort_idx)
+            kwargs[grid_key] = _permute_flat_segments(grid, seg_rows, sort_idx)
+
+        second_per_grid_ts = kwargs.get("second_per_grid_ts")
+        if second_per_grid_ts is not None:
+            if isinstance(second_per_grid_ts, torch.Tensor):
+                kwargs["second_per_grid_ts"] = _permute_flat_segments(second_per_grid_ts, video_rows, sort_idx)
+            else:
+                bounds = [0]
+                for n in video_rows:
+                    bounds.append(bounds[-1] + n)
+                kwargs["second_per_grid_ts"] = [
+                    v for i in sort_idx.tolist() for v in second_per_grid_ts[bounds[i] : bounds[i + 1]]
+                ]

--- a/tests/test_batch_sort_vlm_composition.py
+++ b/tests/test_batch_sort_vlm_composition.py
@@ -1,0 +1,234 @@
+import pytest
+import torch
+
+from optimum.rbln.transformers.models.gemma3.modeling_gemma3 import RBLNGemma3ForConditionalGeneration
+from optimum.rbln.transformers.models.gemma4.modeling_gemma4 import RBLNGemma4ForConditionalGeneration
+from optimum.rbln.transformers.models.idefics3.modeling_idefics3 import RBLNIdefics3ForConditionalGeneration
+from optimum.rbln.transformers.models.llava.modeling_llava import RBLNLlavaForConditionalGeneration
+from optimum.rbln.transformers.models.llava_next.modeling_llava_next import RBLNLlavaNextForConditionalGeneration
+from optimum.rbln.transformers.models.paligemma.modeling_paligemma import RBLNPaliGemmaForConditionalGeneration
+
+
+IMG = 99
+VID = 98
+
+
+def _fake_model(cls, config_fields, lm_attr="language_model", use_batch_attn_opt=True):
+    model = cls.__new__(cls)
+    lm_config = type("Cfg", (), {"use_batch_attn_opt": use_batch_attn_opt})()
+    setattr(model, lm_attr, type("LM", (), {"rbln_config": lm_config})())
+    model.config = type("Config", (), config_fields)()
+    return model
+
+
+def _images_by_sample(image_tensor, images_per_sample, order):
+    # expected image-first layout after permuting samples by `order`
+    segments = torch.split(image_tensor, images_per_sample, dim=0)
+    return torch.cat([segments[i] for i in order], dim=0)
+
+
+# lengths [4, 6, 5] -> descending sample order [1, 2, 0]
+MASK = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 0]])
+SORT = torch.tensor([1, 2, 0])
+
+
+def test_gemma3_sorts_flat_pixel_values():
+    model = _fake_model(RBLNGemma3ForConditionalGeneration, {"image_token_index": IMG, "mm_tokens_per_image": 2})
+    # images per sample: [1, 2, 0], each image = one run of 2 placeholder tokens
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, 3, IMG, IMG, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["attention_mask"], MASK.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_gemma3_gate_off_is_noop():
+    model = _fake_model(
+        RBLNGemma3ForConditionalGeneration,
+        {"image_token_index": IMG, "mm_tokens_per_image": 2},
+        use_batch_attn_opt=None,
+    )
+    input_ids = torch.tensor([[1, 2], [3, 4]])
+    kwargs = {"attention_mask": torch.tensor([[1, 1], [1, 0]]), "pixel_values": torch.zeros(2, 1, 1, 1)}
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+    assert sorted_ids is input_ids
+    assert unsort_idx is None
+    assert "inputs_sorted" not in kwargs
+
+
+def test_gemma3_batch_one_is_noop():
+    model = _fake_model(RBLNGemma3ForConditionalGeneration, {"image_token_index": IMG, "mm_tokens_per_image": 2})
+    input_ids = torch.tensor([[1, IMG, IMG]])
+    kwargs = {"pixel_values": torch.zeros(1, 1, 1, 1)}
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+    assert sorted_ids is input_ids
+    assert unsort_idx is None
+    assert "inputs_sorted" not in kwargs
+
+
+def test_gemma4_sorts_images_and_videos():
+    model = _fake_model(RBLNGemma4ForConditionalGeneration, {"image_token_id": IMG, "video_token_id": VID})
+    # images per sample [1, 0, 1]; one video (2 frames = 2 runs) on sample 1
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [VID, 3, VID, 4, 5, 6], [7, IMG, IMG, IMG, 8, 0]])
+    pixel_values = torch.arange(2, dtype=torch.float).view(2, 1, 1)
+    image_position_ids = torch.arange(2).view(2, 1)
+    pixel_values_videos = torch.arange(2, dtype=torch.float).view(1, 2, 1)
+    video_position_ids = torch.arange(2).view(1, 2, 1)
+    mm_token_type_ids = torch.arange(18).view(3, 6)
+    kwargs = {
+        "attention_mask": MASK.clone(),
+        "pixel_values": pixel_values,
+        "image_position_ids": image_position_ids,
+        "pixel_values_videos": pixel_values_videos,
+        "video_position_ids": video_position_ids,
+        "mm_token_type_ids": mm_token_type_ids,
+    }
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["mm_token_type_ids"], mm_token_type_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 0, 1], SORT.tolist()))
+    assert torch.equal(kwargs["image_position_ids"], _images_by_sample(image_position_ids, [1, 0, 1], SORT.tolist()))
+    # single video belongs to sample 1, which moves to row 0: layout unchanged
+    assert torch.equal(kwargs["pixel_values_videos"], pixel_values_videos)
+    assert torch.equal(kwargs["video_position_ids"], video_position_ids)
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_llava_run_counting_and_image_sizes():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": 2})
+    # images per sample [1, 2, 0] as separated runs
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, 3, IMG, IMG, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    image_sizes = torch.tensor([[8, 8], [16, 16], [32, 32]])
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values, "image_sizes": image_sizes}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+    assert torch.equal(kwargs["image_sizes"], _images_by_sample(image_sizes, [1, 2, 0], SORT.tolist()))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_llava_adjacent_images_fall_back_to_token_count():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": 2})
+    # sample 1 has two adjacent images (one merged run of 4 tokens)
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, IMG, IMG, 3, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values}
+
+    sorted_ids, _ = model._sort_generation_inputs(input_ids, kwargs)
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+
+
+def test_llava_unmappable_images_raise():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": None})
+    # 3 images but only 2 runs and no per-image token count to fall back on
+    input_ids = torch.tensor([[1, IMG, IMG, 2, 0, 0], [IMG, IMG, IMG, IMG, 3, 4]])
+    kwargs = {
+        "attention_mask": torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 1, 1]]),
+        "pixel_values": torch.zeros(3, 1, 1, 1),
+    }
+    with pytest.raises(RuntimeError, match="Cannot map image inputs"):
+        model._sort_generation_inputs(input_ids, kwargs)
+
+
+def test_llava_next_sorts_patched_pixel_values():
+    model = _fake_model(RBLNLlavaNextForConditionalGeneration, {"image_token_index": IMG})
+    # variable-length runs per image; images per sample [1, 2, 0]
+    input_ids = torch.tensor([[1, IMG, IMG, IMG, 0, 0], [IMG, 2, IMG, IMG, 3, 4], [5, 6, 7, 8, 9, 0]])
+    pixel_values = torch.arange(6, dtype=torch.float).view(3, 2, 1, 1, 1)
+    image_sizes = torch.tensor([[8, 8], [16, 16], [32, 32]])
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values, "image_sizes": image_sizes}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], _images_by_sample(pixel_values, [1, 2, 0], SORT.tolist()))
+    assert torch.equal(kwargs["image_sizes"], _images_by_sample(image_sizes, [1, 2, 0], SORT.tolist()))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_idefics3_sorts_batch_first_pixel_values():
+    vision_config = type("VisionCfg", (), {"image_size": 4, "patch_size": 2})()
+    model = _fake_model(
+        RBLNIdefics3ForConditionalGeneration,
+        {"image_token_id": IMG, "vision_config": vision_config, "scale_factor": 2},
+        lm_attr="text_model",
+    )
+    input_ids = torch.tensor([[1, IMG, 2, 0, 0, 0], [IMG, 3, IMG, 4, 5, 6], [7, 8, 9, 10, 11, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1, 1)
+    pixel_attention_mask = torch.arange(12).view(3, 1, 2, 2)
+    kwargs = {
+        "attention_mask": MASK.clone(),
+        "pixel_values": pixel_values,
+        "pixel_attention_mask": pixel_attention_mask,
+    }
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], pixel_values.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_attention_mask"], pixel_attention_mask.index_select(0, SORT))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_idefics3_sorts_image_hidden_states():
+    # (image_size // patch_size)**2 // scale_factor**2 = 1 placeholder token per patch image
+    vision_config = type("VisionCfg", (), {"image_size": 4, "patch_size": 2})()
+    model = _fake_model(
+        RBLNIdefics3ForConditionalGeneration,
+        {"image_token_id": IMG, "vision_config": vision_config, "scale_factor": 2},
+        lm_attr="text_model",
+    )
+    input_ids = torch.tensor([[1, IMG, 2, 0, 0, 0], [IMG, 3, IMG, 4, 5, 6], [7, 8, 9, 10, 11, 0]])
+    image_hidden_states = torch.arange(3, dtype=torch.float).view(3, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "image_hidden_states": image_hidden_states}
+
+    sorted_ids, _ = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["image_hidden_states"], _images_by_sample(image_hidden_states, [1, 2, 0], SORT.tolist()))
+
+
+def test_paligemma_sorts_batch_first_pixel_values():
+    model = _fake_model(RBLNPaliGemmaForConditionalGeneration, {"image_token_id": IMG})
+    input_ids = torch.tensor([[IMG, 1, 2, 0, 0, 0], [IMG, 3, 4, 5, 6, 7], [IMG, 8, 9, 10, 11, 0]])
+    pixel_values = torch.arange(3, dtype=torch.float).view(3, 1, 1, 1)
+    kwargs = {"attention_mask": MASK.clone(), "pixel_values": pixel_values}
+
+    sorted_ids, unsort_idx = model._sort_generation_inputs(input_ids, kwargs)
+
+    assert torch.equal(sorted_ids, input_ids.index_select(0, SORT))
+    assert torch.equal(kwargs["pixel_values"], pixel_values.index_select(0, SORT))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(model._unsort_generation_outputs(sorted_ids, unsort_idx), input_ids)
+
+
+def test_forward_guard_requires_sorted_inputs():
+    model = _fake_model(RBLNLlavaForConditionalGeneration, {"image_token_index": IMG, "image_seq_length": 2})
+    batch_input = torch.zeros(2, 4, dtype=torch.long)
+    with pytest.raises(RuntimeError, match="use_batch_attn_opt"):
+        model._require_sorted_batch_inputs(batch_input, inputs_sorted=False)
+    model._require_sorted_batch_inputs(batch_input, inputs_sorted=True)
+    model._require_sorted_batch_inputs(batch_input[:1], inputs_sorted=False)
+
+    disabled = _fake_model(
+        RBLNLlavaForConditionalGeneration,
+        {"image_token_index": IMG, "image_seq_length": 2},
+        use_batch_attn_opt=None,
+    )
+    disabled._require_sorted_batch_inputs(batch_input, inputs_sorted=False)

--- a/tests/test_batch_sort_vlm_flatten.py
+++ b/tests/test_batch_sort_vlm_flatten.py
@@ -6,11 +6,9 @@ import torch
 from optimum.rbln.transformers.models.decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from optimum.rbln.transformers.models.exaone4_5.modeling_exaone4_5 import RBLNExaone4_5_ForConditionalGeneration
 from optimum.rbln.transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import RBLNQwen2_5_VLForConditionalGeneration
-from optimum.rbln.transformers.models.qwen2_vl.modeling_qwen2_vl import (
-    RBLNQwen2VLForConditionalGeneration,
-    RBLNVisionBatchSortMixin,
-)
+from optimum.rbln.transformers.models.qwen2_vl.modeling_qwen2_vl import RBLNQwen2VLForConditionalGeneration
 from optimum.rbln.transformers.models.qwen3_vl.modeling_qwen3_vl import RBLNQwen3VLForConditionalGeneration
+from optimum.rbln.transformers.utils.generation_multimodal import RBLNVisionBatchSortMixin
 
 
 VS, IMG, VID = 90, 91, 92
@@ -210,17 +208,17 @@ def test_gate_off_noop():
     assert "inputs_sorted" not in kwargs
 
 
-def test_check_batch_inputs_sorted_guard():
+def test_require_sorted_batch_inputs_guard():
     model = _make_model(RBLNQwen2VLForConditionalGeneration)
     batch = torch.zeros(2, 4, dtype=torch.long)
     with pytest.raises(RuntimeError, match="sorted by sequence length"):
-        model._check_batch_inputs_sorted(batch, False)
-    model._check_batch_inputs_sorted(batch, True)
-    model._check_batch_inputs_sorted(batch[:1], False)
-    model._check_batch_inputs_sorted(None, False)
+        model._require_sorted_batch_inputs(batch, False)
+    model._require_sorted_batch_inputs(batch, True)
+    model._require_sorted_batch_inputs(batch[:1], False)
+    model._require_sorted_batch_inputs(None, False)
 
     off = _make_model(RBLNQwen2VLForConditionalGeneration, use_batch_attn_opt=False)
-    off._check_batch_inputs_sorted(batch, False)
+    off._require_sorted_batch_inputs(batch, False)
 
 
 def test_sort_requires_input_ids_for_vision():

--- a/tests/test_batch_sort_vlm_flatten.py
+++ b/tests/test_batch_sort_vlm_flatten.py
@@ -1,0 +1,234 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from optimum.rbln.transformers.models.decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
+from optimum.rbln.transformers.models.exaone4_5.modeling_exaone4_5 import RBLNExaone4_5_ForConditionalGeneration
+from optimum.rbln.transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import RBLNQwen2_5_VLForConditionalGeneration
+from optimum.rbln.transformers.models.qwen2_vl.modeling_qwen2_vl import (
+    RBLNQwen2VLForConditionalGeneration,
+    RBLNVisionBatchSortMixin,
+)
+from optimum.rbln.transformers.models.qwen3_vl.modeling_qwen3_vl import RBLNQwen3VLForConditionalGeneration
+
+
+VS, IMG, VID = 90, 91, 92
+
+
+def _make_model(cls, use_batch_attn_opt=True, **config_attrs):
+    model = object.__new__(cls)
+    model.rbln_config = SimpleNamespace(use_batch_attn_opt=use_batch_attn_opt)
+    model.config = SimpleNamespace(vision_start_token_id=VS, image_token_id=IMG, video_token_id=VID, **config_attrs)
+    return model
+
+
+def test_qwen2_vl_sort_vision_inputs():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration)
+    # lengths [4, 6, 5]; images per sample [2, 0, 1]; one video on sample 2
+    ids = torch.tensor(
+        [
+            [0, 0, VS, IMG, VS, IMG],
+            [1, 2, 3, 4, 5, 6],
+            [0, VS, IMG, VS, VID, 8],
+        ]
+    )
+    mask = torch.tensor([[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+    grids = torch.tensor([[1, 2, 2], [1, 2, 4], [1, 2, 6]])  # 4 + 8 patches (s0), 12 patches (s2)
+    pixels = torch.arange(24 * 3).reshape(24, 3)
+    video_grids = torch.tensor([[2, 2, 2]])
+    video_pixels = torch.arange(8 * 3).reshape(8, 3)
+
+    kwargs = {
+        "attention_mask": mask,
+        "pixel_values": pixels,
+        "image_grid_thw": grids,
+        "pixel_values_videos": video_pixels,
+        "video_grid_thw": video_grids,
+    }
+    sorted_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+
+    sort_idx = torch.tensor([1, 2, 0])  # lengths 6, 5, 4 descending
+    assert torch.equal(sorted_ids, ids.index_select(0, sort_idx))
+    assert torch.equal(kwargs["attention_mask"], mask.index_select(0, sort_idx))
+    assert kwargs["inputs_sorted"] is True
+    # image order becomes: (none from s1), s2's, then s0's two
+    assert torch.equal(kwargs["image_grid_thw"], grids[[2, 0, 1]])
+    assert torch.equal(kwargs["pixel_values"], torch.cat([pixels[12:24], pixels[0:12]]))
+    # single video: segments unchanged
+    assert torch.equal(kwargs["video_grid_thw"], video_grids)
+    assert torch.equal(kwargs["pixel_values_videos"], video_pixels)
+    # roundtrip restores original order
+    assert torch.equal(RBLNDecoderOnlyGenerationMixin._unsort_generation_outputs(sorted_ids, unsort_idx), ids)
+
+
+def test_qwen2_5_vl_videos_and_second_per_grid_ts():
+    model = _make_model(RBLNQwen2_5_VLForConditionalGeneration)
+    # lengths [4, 6, 5]; videos per sample [1, 0, 2]
+    ids = torch.tensor(
+        [
+            [0, 0, VS, VID, 7, 7],
+            [1, 2, 3, 4, 5, 6],
+            [0, VS, VID, VS, VID, 9],
+        ]
+    )
+    mask = torch.tensor([[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+    video_grids = torch.tensor([[1, 2, 2], [1, 2, 4], [2, 2, 2]])  # 4 (s0), 8 + 8 (s2)
+    video_pixels = torch.arange(20 * 2).reshape(20, 2)
+    ts = torch.tensor([0.1, 0.2, 0.3])
+
+    kwargs = {
+        "attention_mask": mask,
+        "pixel_values_videos": video_pixels,
+        "video_grid_thw": video_grids,
+        "second_per_grid_ts": ts,
+    }
+    sorted_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+
+    sort_idx = torch.tensor([1, 2, 0])
+    assert torch.equal(sorted_ids, ids.index_select(0, sort_idx))
+    assert torch.equal(kwargs["video_grid_thw"], video_grids[[1, 2, 0]])
+    assert torch.equal(kwargs["pixel_values_videos"], torch.cat([video_pixels[4:20], video_pixels[0:4]]))
+    assert torch.equal(kwargs["second_per_grid_ts"], torch.tensor([0.2, 0.3, 0.1]))
+    assert torch.equal(RBLNDecoderOnlyGenerationMixin._unsort_generation_outputs(sorted_ids, unsort_idx), ids)
+
+
+def test_qwen2_5_vl_second_per_grid_ts_list():
+    model = _make_model(RBLNQwen2_5_VLForConditionalGeneration)
+    ids = torch.tensor([[0, 0, VS, VID, 7, 7], [1, 2, 3, 4, 5, 6], [0, VS, VID, VS, VID, 9]])
+    mask = torch.tensor([[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+    kwargs = {
+        "attention_mask": mask,
+        "video_grid_thw": torch.tensor([[1, 2, 2], [1, 2, 4], [2, 2, 2]]),
+        "second_per_grid_ts": [0.1, 0.2, 0.3],
+    }
+    model._sort_generation_inputs(ids, kwargs)
+    assert kwargs["second_per_grid_ts"] == [0.2, 0.3, 0.1]
+
+
+def test_qwen3_vl_chunked_video_grid_rows():
+    model = _make_model(RBLNQwen3VLForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # sample 0: one video split into 2 temporal chunks (2 markers, one grid row with t=2)
+    # sample 1: one video with 1 chunk
+    ids = torch.tensor([[0, VS, VID, VS, VID, 7], [1, 2, 3, VS, VID, 6]])
+    mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    video_grids = torch.tensor([[2, 2, 2], [1, 2, 2]])  # 8 patches (s0), 4 patches (s1)
+    video_pixels = torch.arange(12 * 2).reshape(12, 2)
+
+    kwargs = {"attention_mask": mask, "pixel_values_videos": video_pixels, "video_grid_thw": video_grids}
+    sorted_ids, _ = model._sort_generation_inputs(ids, kwargs)
+
+    assert torch.equal(sorted_ids, ids.index_select(0, torch.tensor([1, 0])))
+    assert torch.equal(kwargs["video_grid_thw"], video_grids[[1, 0]])
+    assert torch.equal(kwargs["pixel_values_videos"], torch.cat([video_pixels[8:12], video_pixels[0:8]]))
+
+
+def test_qwen3_vl_precomputed_embeds():
+    model = _make_model(RBLNQwen3VLForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # images per sample [1, 1]; merged tokens = patches // 4: 2 (s0), 4 (s1)
+    ids = torch.tensor([[0, VS, IMG, 5, 5, 5], [VS, IMG, 3, 4, 5, 6]])
+    mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    grids = torch.tensor([[1, 2, 4], [1, 4, 4]])
+    embeds = torch.arange(6 * 2).reshape(6, 2).float()
+    deepstack = [embeds * 10, embeds * 100]
+
+    kwargs = {
+        "attention_mask": mask,
+        "image_grid_thw": grids,
+        "image_embeds": embeds,
+        "deepstack_image_embeds": deepstack,
+    }
+    model._sort_generation_inputs(ids, kwargs)
+
+    assert torch.equal(kwargs["image_grid_thw"], grids[[1, 0]])
+    assert torch.equal(kwargs["image_embeds"], torch.cat([embeds[2:6], embeds[0:2]]))
+    for scale, layer in zip((10, 100), kwargs["deepstack_image_embeds"], strict=True):
+        assert torch.equal(layer, torch.cat([embeds[2:6], embeds[0:2]]) * scale)
+
+
+def test_qwen3_vl_moe_inherits_mixin():
+    from optimum.rbln.transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
+        RBLNQwen3VLMoeForConditionalGeneration,
+    )
+
+    assert issubclass(RBLNQwen3VLMoeForConditionalGeneration, RBLNVisionBatchSortMixin)
+    assert RBLNQwen3VLMoeForConditionalGeneration._video_grid_rows_are_chunks is True
+
+
+def test_qwen3_5_inherits_mixin():
+    from optimum.rbln.transformers.models.qwen3_5.modeling_qwen3_5 import RBLNQwen3_5ForConditionalGeneration
+
+    assert issubclass(RBLNQwen3_5ForConditionalGeneration, RBLNVisionBatchSortMixin)
+    assert RBLNQwen3_5ForConditionalGeneration._video_grid_rows_are_chunks is True
+
+
+def test_exaone4_5_token_count_rows():
+    model = _make_model(RBLNExaone4_5_ForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # no vision_start marker; merged tokens per grid: 1, 2 (sample 0) and 4 (sample 2)
+    ids = torch.tensor(
+        [
+            [0, 0, 0, IMG, IMG, IMG, 5],
+            [1, 2, 3, 4, 5, 6, 7],
+            [0, IMG, IMG, IMG, IMG, 9, 9],
+        ]
+    )
+    mask = torch.tensor([[0, 0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1, 1]])
+    grids = torch.tensor([[1, 2, 2], [1, 2, 4], [1, 4, 4]])  # 4 + 8 patches (s0), 16 patches (s2)
+    pixels = torch.arange(28 * 3).reshape(28, 3)
+
+    kwargs = {"attention_mask": mask, "pixel_values": pixels, "image_grid_thw": grids}
+    sorted_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+
+    sort_idx = torch.tensor([1, 2, 0])  # lengths 7, 6, 4 descending
+    assert torch.equal(sorted_ids, ids.index_select(0, sort_idx))
+    assert kwargs["inputs_sorted"] is True
+    assert torch.equal(kwargs["image_grid_thw"], grids[[2, 0, 1]])
+    assert torch.equal(kwargs["pixel_values"], torch.cat([pixels[12:28], pixels[0:12]]))
+    assert torch.equal(RBLNDecoderOnlyGenerationMixin._unsort_generation_outputs(sorted_ids, unsort_idx), ids)
+
+
+def test_exaone4_5_misaligned_grids_raise():
+    model = _make_model(RBLNExaone4_5_ForConditionalGeneration, vision_config=SimpleNamespace(spatial_merge_size=2))
+    # sample 0 has 2 image tokens but the first grid yields 4 merged tokens
+    ids = torch.tensor([[IMG, IMG, 3, 4], [1, 2, 3, 4]])
+    kwargs = {"pixel_values": torch.zeros(16, 3), "image_grid_thw": torch.tensor([[1, 4, 4]])}
+    with pytest.raises(ValueError, match="do not align"):
+        model._sort_generation_inputs(ids, kwargs)
+
+
+def test_gate_off_noop():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration, use_batch_attn_opt=False)
+    ids = torch.tensor([[0, VS, IMG, 3], [1, 2, 3, 4]])
+    grids = torch.tensor([[1, 2, 2]])
+    pixels = torch.zeros(4, 3)
+    kwargs = {"pixel_values": pixels, "image_grid_thw": grids}
+    out_ids, unsort_idx = model._sort_generation_inputs(ids, kwargs)
+    assert out_ids is ids
+    assert unsort_idx is None
+    assert kwargs["pixel_values"] is pixels
+    assert kwargs["image_grid_thw"] is grids
+    assert "inputs_sorted" not in kwargs
+
+
+def test_check_batch_inputs_sorted_guard():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration)
+    batch = torch.zeros(2, 4, dtype=torch.long)
+    with pytest.raises(RuntimeError, match="sorted by sequence length"):
+        model._check_batch_inputs_sorted(batch, False)
+    model._check_batch_inputs_sorted(batch, True)
+    model._check_batch_inputs_sorted(batch[:1], False)
+    model._check_batch_inputs_sorted(None, False)
+
+    off = _make_model(RBLNQwen2VLForConditionalGeneration, use_batch_attn_opt=False)
+    off._check_batch_inputs_sorted(batch, False)
+
+
+def test_sort_requires_input_ids_for_vision():
+    model = _make_model(RBLNQwen2VLForConditionalGeneration)
+    kwargs = {
+        "inputs_embeds": torch.zeros(2, 4, 8),
+        "pixel_values": torch.zeros(4, 3),
+        "image_grid_thw": torch.tensor([[1, 2, 2]]),
+    }
+    with pytest.raises(RuntimeError, match="requires input_ids"):
+        model._sort_generation_inputs(None, kwargs)


### PR DESCRIPTION
## What

Batch-input sorting for every multimodal family, unified from #705 and #706 (both superseded by this PR). Stacked on #704.

On RBLN-CR13+ the compiler routes mask-less flash attention to the in-memory batched kernel, which requires batch inputs sorted by sequence length (descending). All VLM families bypass `RBLNDecoderOnlyModelForCausalLM.forward`, so generate-entry sorting is their only path — and their image inputs cannot be permuted by a plain batch-dim `index_select`.

One module now owns the machinery: `src/optimum/rbln/transformers/utils/generation_multimodal.py`

- `RBLNBatchSortGuardMixin` — the shared forward guard (`_require_sorted_batch_inputs`): these forwards drive `prefill_decoder`/`decoder` themselves, so an unsorted direct multi-batch call raises instead of silently mis-laying the KV cache.
- `RBLNMultimodalBatchSortMixin` — composition families (top-level config is a plain `RBLNModelConfig`): gate reads the inner LM's config via `_lm_attr_name`; image-first tensors are mapped to batch rows by placeholder-token runs (tokens-per-image fallback).
- `RBLNVisionBatchSortMixin` — flatten-patch direct subclasses (config already carries `use_batch_attn_opt`, so without this PR the base fast-path would sort text while images stay unsorted): per-sample image/video grid-row counts follow each family's own `_preprocess_prefill` counting; `pixel_values`/grids/`second_per_grid_ts` permuted segment-wise. Extension points: `_video_grid_rows_are_chunks` (qwen3-style temporal-chunk grids), overridable `_vision_grid_rows_per_sample`/`_sort_vision_kwargs`.

## Families

- Composition: gemma3, gemma4 (images+videos), paligemma, llava, llava_next, idefics3 (blip2 verified covered by its inner-LM `generate` delegation — no change).
- Flatten: qwen2_vl, qwen2_5_vl, qwen3_vl (incl. pre-embedded encoder-node path), qwen3_vl_moe (via inheritance), qwen3_5, exaone4_5 (no `vision_start_token_id` — placeholder-token-count matching with explicit misalignment error).

Known limitation: pixtral-style multi-image llava batches (`[IMG_BREAK]` splits runs) raise the explicit "pass pre-sorted" error instead of sorting.

## Test

Host-side, no NPU: `tests/test_batch_sort_vlm_composition.py` (12) + `tests/test_batch_sort_vlm_flatten.py` (12) + existing `tests/test_batch_attn_sort.py` (12) — 36 passed; ruff clean. End-to-end NPU generate not yet verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)