### PR TITLE
performance(memory): size the KV cache from the joint allocation, not the sum

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -10,6 +10,8 @@ from ..utils.runtime_utils import get_available_dram_per_chiplet, parse_byte_siz
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .models.decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelForCausalLMConfig
 
 
@@ -134,15 +136,60 @@ def align_2MB(x: int) -> int:
     return align(x, 2**21)
 
 
-def get_alloc_memory_by_key(compiled_models: dict[str, rebel.RBLNCompiledModel]) -> dict[str, int]:
-    alloc_memory_by_key = defaultdict(int)
-    # Get the actual memory allocation of each node by key
-    for compiled_model in compiled_models.values():
-        alloc_per_node_by_key = compiled_model.get_alloc_per_node_by_key()
-        for key, memory_per_node in alloc_per_node_by_key.items():
-            alloc_memory_by_key[key] += sum(memory_per_node)
+def _joint_report(compiled_models: "Iterable[rebel.RBLNCompiledModel]", api_name: str):
+    """The compiler's joint allocation report for `compiled_models`, or None to sum per model.
 
-    return alloc_memory_by_key
+    Models compiled in one `CompileContext` share their weight pool, and each model's own
+    report includes the pool it needs resident, so adding the reports up charges one device
+    allocation once per model. The compiler's set-based API runs a single dedup over the
+    whole set instead. It returns None when the compiler is too old to have the API, and when
+    the artifacts turn out to come from different compile contexts — those share nothing, so
+    summing them per model is already the right answer.
+    """
+    api = getattr(rebel, api_name, None)
+    if api is None:
+        return None
+    try:
+        return api(compiled_models)
+    except RuntimeError:
+        return None
+
+
+def alloc_per_node_by_key(compiled_models: "Iterable[rebel.RBLNCompiledModel]") -> dict[str, list[int]]:
+    """Device memory the models allocate together on each NPU, by memory key."""
+    compiled_models = list(compiled_models)
+    joint = _joint_report(compiled_models, "exp_get_alloc_per_node_by_key")
+    if joint is not None:
+        return joint
+
+    total: dict[str, list[int]] = {}
+    for compiled_model in compiled_models:
+        for key, sizes_at_node in compiled_model.get_alloc_per_node_by_key().items():
+            accumulated = total.setdefault(key, [0] * len(sizes_at_node))
+            for node_id, size in enumerate(sizes_at_node):
+                accumulated[node_id] += size
+    return total
+
+
+def alloc_per_chiplet_by_key(compiled_models: "Iterable[rebel.RBLNCompiledModel]") -> dict[str, list[list[int]]]:
+    """Per-chiplet counterpart of `alloc_per_node_by_key`, indexed [node_id][chiplet_id]."""
+    compiled_models = list(compiled_models)
+    joint = _joint_report(compiled_models, "exp_get_alloc_per_chiplet_by_key")
+    if joint is not None:
+        return joint
+
+    total: dict[str, list[list[int]]] = {}
+    for compiled_model in compiled_models:
+        for key, sizes_at_node in compiled_model.get_alloc_per_chiplet_by_key().items():
+            accumulated = total.setdefault(key, [[0] * len(sizes_at_chiplet) for sizes_at_chiplet in sizes_at_node])
+            for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                for chiplet_id, size in enumerate(sizes_at_chiplet):
+                    accumulated[node_id][chiplet_id] += size
+    return total
+
+
+def get_alloc_memory_by_key(compiled_models: dict[str, rebel.RBLNCompiledModel]) -> dict[str, int]:
+    return {key: sum(sizes_at_node) for key, sizes_at_node in alloc_per_node_by_key(compiled_models.values()).items()}
 
 
 def format_byte_size(nbytes: int) -> str:
@@ -256,14 +303,13 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         alloc_without_dram: dict[tuple[int, int], int] = defaultdict(int)
         chiplets: set[tuple[int, int]] = set()
 
-        for compiled_model in compiled_models.values():
-            for key, alloc_per_chiplet in compiled_model.get_alloc_per_chiplet_by_key().items():
-                if key == "DramTensor":
-                    continue
-                for node_id, sizes_at_chiplet in enumerate(alloc_per_chiplet):
-                    for chiplet_id, size in enumerate(sizes_at_chiplet):
-                        alloc_without_dram[(node_id, chiplet_id)] += size
-                        chiplets.add((node_id, chiplet_id))
+        for key, alloc_per_chiplet in alloc_per_chiplet_by_key(compiled_models.values()).items():
+            if key == "DramTensor":
+                continue
+            for node_id, sizes_at_chiplet in enumerate(alloc_per_chiplet):
+                for chiplet_id, size in enumerate(sizes_at_chiplet):
+                    alloc_without_dram[(node_id, chiplet_id)] += size
+                    chiplets.add((node_id, chiplet_id))
 
         # kvcache_tensor_sizes[key][node_id][chiplet_id] = alloc_size
         kvcache_tensor_sizes: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Performance improvement

## Changes Overview

The device memory figure that sizes the KV cache is now computed over the whole set of compiled artifacts instead of one artifact at a time.

- Adds `alloc_per_node_by_key` and `alloc_per_chiplet_by_key`. Each uses the compiler's set-based API when it is available and otherwise falls back to today's per-model sum.
- Replaces the per-model loops in `get_alloc_memory_by_key` and `_collect_chiplet_kvcache_inputs` with calls to those helpers.
- Leaves the debug logging in `_log_memory_usage` alone: it exists to show the per-phase breakdown.

## Motivation and Context

The compiler's allocation accounting now dedups on `buffer_id`, so an artifact that borrows a sibling's weight pool reports the pool it needs resident rather than nothing at all. That is correct for a single artifact — the pool has to be on the device before that artifact can run. It goes wrong the moment the phases are added together: one device allocation is charged once per phase that names it.

`prefill` and `decoder` share a single `CompileContext`, so this is exactly the situation here. Measured on Qwen3-1.7B, tp1, the non-`DramTensor` allocation comes out as:

| accounting | non-DramTensor allocation |
| --- | --- |
| sum of per-model reports (today) | 7,038,042,112 B (6.55 GiB) |
| joint over the set (this PR) | 3,577,741,312 B (3.33 GiB) |

3.2 GiB of that never exists on the device, and it comes straight out of the KV cache budget. Against the available DRAM of a single ATOM that is well over 20% of the card, which is how a compile ends up refused for want of blocks.

Where memory is the binding constraint rather than the batch size, that budget turns directly into blocks. Qwen3-1.7B, tp1, `max_seq_len=32768`, `kvcache_partition_len=4096`, `batch_size=4`:

| accounting | kvcache_num_blocks |
| --- | --- |
| sum of per-model reports (today) | 20 |
| joint over the set (this PR) | 28 |

The same device holds 40% more KV cache once it is asked what it actually allocates. At `batch_size=1` both give the same answer, because there the block count is capped by one sequence's worth of blocks long before memory runs out.

`rebel.exp_get_alloc_per_node_by_key` and `rebel.exp_get_alloc_per_chiplet_by_key` take the whole set and run the dedup once across it.

## Compatibility with older compilers

The helpers look the API up with `getattr` and, when it is absent, take a per-model sum that is byte-for-byte what the code does today. Nothing changes on an older compiler.

The same fallback covers one more case. The compiler refuses to dedup artifacts that come from different compile contexts, because a raw buffer id names a buffer only within the compile session that minted it — deduping across sessions would merge unrelated buffers and under-report the footprint. Artifacts compiled apart share nothing, though, so the per-model sum is already the right answer for them. A refusal therefore falls through to the sum instead of raising.

## Verification

- Ran both paths over the same set of artifacts: the return shapes agree, and the shared weight pool is charged once on the new path and twice on the fallback.
- On both paths, the per-chiplet figures sum to the per-node figures for every memory key.
- Passing artifacts from different compile contexts returns the same value as the per-model sum, with no exception.
- `tests/test_config.py`: 42 passed, 4 skipped.
- `ruff check` and `ruff format --check` are clean.

## Related Issues

The compiler-side API is added in rebellions-sw/rebel_compiler#12884. This PR's fallback path works until that lands, so there is no ordering constraint between the two.
