### PR TITLE
model(qwen3.5): restore HF fp32 casts in the GatedDeltaNet kernel

### DIFF
--- a/src/optimum/rbln/transformers/models/qwen3_5/qwen3_5_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/qwen3_5_architecture.py
@@ -142,7 +142,7 @@ def rbln_chunk_gated_delta_rule(
         query = l2norm(query, dim=-1, eps=1e-6)
         key = l2norm(key, dim=-1, eps=1e-6)
     query, key, value, beta, g = [
-        x.transpose(1, 2).contiguous().to(initial_dtype) for x in (query, key, value, beta, g)
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
     ]
     scale = 1 / (query.shape[-1] ** 0.5)
     query = query * scale
@@ -171,7 +171,7 @@ def rbln_chunk_gated_delta_rule(
     # entry, so reshaping it to 4D (B, Hv, Dk, Dv) here is safe.
     last_recurrent_state = initial_state.reshape(
         initial_state.shape[0], query.shape[1], query.shape[-1], value.shape[-1]
-    )
+    ).to(torch.float32)
 
     # inter-chunk: sequential carry across sub-chunks.
     core_chunks = []
@@ -193,13 +193,13 @@ def rbln_chunk_gated_delta_rule(
 
     # concat sub-chunk outputs along seq
     core = torch.cat(core_chunks, dim=2)
-    core = core.transpose(1, 2).contiguous()
+    core = core.transpose(1, 2).contiguous().to(initial_dtype)
     # return the final state in the 3D cache layout (B, Hv*Dk, Dv) to match the static cache.
     last_recurrent_state = last_recurrent_state.reshape(
         last_recurrent_state.shape[0],
         last_recurrent_state.shape[1] * last_recurrent_state.shape[2],
         last_recurrent_state.shape[3],
-    )
+    ).to(initial_dtype)
     return core, last_recurrent_state
 
 
@@ -211,6 +211,8 @@ def rbln_recurrent_gated_delta_rule_step(query, key, value, g, beta, initial_sta
     cache and reshaped to 4D here only after a compute (``* g_t``).
     """
     initial_dtype = query.dtype
+    query, key, value, g, beta = [x.to(torch.float32) for x in (query, key, value, g, beta)]
+    initial_state = initial_state.to(torch.float32)
     batch_size, _, num_v_heads, k_head_dim = query.shape
     v_head_dim = value.shape[-1]
     q = query.reshape(batch_size, num_v_heads, k_head_dim)
@@ -374,7 +376,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
 
         beta = b.sigmoid()
-        g = -self.A_log.exp() * F.softplus(a + self.dt_bias)
+        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
         if prefill:
             # padding tokens have nonzero q/k/v/g via biases; zero g/beta so they don't pollute the recurrent-state sum and its decay.
             g = g * valid_mask


### PR DESCRIPTION
## Summary

Restores the fp32 compute that HF's `torch_chunk_gated_delta_rule` / `torch_recurrent_gated_delta_rule`
use inside the GatedDeltaNet kernel, which the RBLN rewrite had intentionally dropped. The kernel now
matches HF semantics:

- **Chunk (prefill) rule**: upcast the inputs (`q/k/v/beta/g`) and the carried `initial_state` to fp32;
  cast the outputs (`core`, `last_recurrent_state`) back to the graph dtype at the kernel boundary.
- **Single-step (decode) rule**: same input/state upcast (outputs were already cast back).
- **Gate**: `g = -A_log.float().exp() * softplus(a.float() + dt_bias)` — per HF's comment, this guards
  `A_log.exp()` from overflowing to `-inf` when the model runs in fp16 (bf16 shares fp32's exponent
  range, so the default bf16 path was never at risk).

## Why now

The casts were originally removed to keep the kernel in a single device dtype. A device experiment shows
the fp32 island is safe to restore, so we take the HF-faithful form:

- **Compiles**: the fp32 island — including fp32 `rbln::tri_recur_update` — lowers without issues.
- **Parity on par** (4-layer real Qwen3.5-0.8B, teacher-forced 30 steps, flash attn):

| | single-dtype (before) | fp32 kernel (this PR) |
| --- | --- | --- |
| logit pearson mean | 0.99985 | 0.99985 |
| logit pearson min | 0.99957 | 0.99963 |
| argmax match | 29/30 | 28/30 (extra flip is a near-tie, HF top1-top2 gap 0.125) |

The default path loads the checkpoint in bf16 (transformers v5 `dtype="auto"`), where the upcast adds no
information — parity is unchanged, as expected. The gain is HF fidelity and the fp16-load guard.

## Testing

- Device parity: 4-layer real-weight teacher-forced run (above).
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
