### PR TITLE
model: restore HF dtype casts dropped for the single-dtype compiler

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -479,7 +479,10 @@ class DecoderOnlyModel(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.get_embedding()(input_ids)
 
-        hidden_states = inputs_embeds * self.hidden_multiplier
+        hidden_states = inputs_embeds
+        if self.hidden_multiplier != 1:
+            # HF rounds the scale to the embedding dtype before multiplying (e.g. sqrt(3072) -> 55.5 in bf16).
+            hidden_states = hidden_states * torch.tensor(self.hidden_multiplier, dtype=hidden_states.dtype)
 
         # get cos,sin vector if needed
         position_ids = position_ids if position_ids is not None else cache_position
@@ -1324,8 +1327,8 @@ class RotaryEmbedding(nn.Module):
 
     def forward(self, x, seq_len):
         return (
-            self._cos_cached[:seq_len].to(dtype=torch.float32),
-            self._sin_cached[:seq_len].to(dtype=torch.float32),
+            self._cos_cached[:seq_len].to(dtype=x.dtype),
+            self._sin_cached[:seq_len].to(dtype=x.dtype),
         )
 
 
@@ -1355,11 +1358,8 @@ def rotate_half(x):
 
 def apply_rotary_pos_emb(q, k, cos, sin):
     """Applies Rotary Position Embedding to the query and key tensors."""
-    dtype = q.dtype
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
-    q_embed = q_embed.to(dtype)
-    k_embed = k_embed.to(dtype)
     return q_embed, k_embed
 
 

--- a/src/optimum/rbln/transformers/models/exaone4_5/exaone4_5_architecture.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/exaone4_5_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -22,7 +21,7 @@ from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyAttention,
     DecoderOnlyLayer,
     DecoderOnlyWrapper,
-    apply_rotary_pos_emb,
+    rotate_half,
 )
 from .configuration_exaone4_5 import RBLNExaone4_5_VisionModelConfig
 
@@ -106,6 +105,16 @@ class Exaone4_5VisionBlock(torch.nn.Module):
         return hidden_states
 
 
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    # Mirrors HF `apply_rotary_pos_emb_vision`: rotate in fp32 and round once.
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.float(), sin.float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
+
+
 class Exaone4_5VisionFullAttention(nn.Module):
     def __init__(self, model: nn.Module, rbln_config: RBLNExaone4_5_VisionModelConfig) -> None:
         super().__init__()
@@ -118,7 +127,7 @@ class Exaone4_5VisionFullAttention(nn.Module):
         self.kv_dim = self.num_key_value_heads * self.head_dim
         self.qkv = model.qkv
         self.proj = model.proj
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -144,7 +153,7 @@ class Exaone4_5VisionFullAttention(nn.Module):
             v = v.repeat_interleave(repeat_factor, dim=1).permute(1, 0, 2).unsqueeze(0)
 
         cos, sin = position_embeddings
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
 
         attn_output = nn.functional.scaled_dot_product_attention(
             q,
@@ -153,7 +162,7 @@ class Exaone4_5VisionFullAttention(nn.Module):
             attn_mask=attn_masks,
             dropout_p=0.0,
             is_causal=False,
-            scale=self.scale.item(),
+            scale=self.scale,
         )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)
@@ -174,7 +183,7 @@ class Exaone4_5VisionWindowAttention(nn.Module):
         self.qkv = model.qkv
         self.proj = model.proj
         self.window_seq_len = window_seq_len
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -207,7 +216,7 @@ class Exaone4_5VisionWindowAttention(nn.Module):
         cos, sin = position_embeddings
         cos = cos.reshape(num_windows, 1, seq_length // num_windows, -1)
         sin = sin.reshape(num_windows, 1, seq_length // num_windows, -1)
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
 
         attn_output = nn.functional.scaled_dot_product_attention(
             q,
@@ -216,7 +225,7 @@ class Exaone4_5VisionWindowAttention(nn.Module):
             attn_mask=attn_masks,
             dropout_p=0.0,
             is_causal=False,
-            scale=self.scale.item(),
+            scale=self.scale,
         )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)

--- a/src/optimum/rbln/transformers/models/grounding_dino/grounding_dino_architecture.py
+++ b/src/optimum/rbln/transformers/models/grounding_dino/grounding_dino_architecture.py
@@ -229,8 +229,8 @@ class _GroundingDinoDecoder(torch.nn.Module):
             text_encoder_attention_mask = text_encoder_attention_mask.repeat(
                 1, self.config.decoder_attention_heads, self.config.num_queries, 1
             )
-            text_encoder_attention_mask = text_encoder_attention_mask
-            text_encoder_attention_mask = text_encoder_attention_mask * torch.finfo(torch.float16).min
+            dtype = text_encoder_hidden_states.dtype
+            text_encoder_attention_mask = text_encoder_attention_mask.to(dtype) * torch.finfo(dtype).min
 
         for idx, decoder_layer in enumerate(self.layers):
             num_coordinates = reference_points.shape[-1]
@@ -243,7 +243,7 @@ class _GroundingDinoDecoder(torch.nn.Module):
             else:
                 raise ValueError("Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
             _query_pos = get_sine_pos_embed(reference_points_input[:, :, 0, :], num_pos_feats=self.config.d_model // 2)
-            query_pos = self.reference_points_head(_query_pos)
+            query_pos = self.reference_points_head(_query_pos.to(hidden_states.dtype))
 
             # In original implementation they apply layer norm before outputting intermediate hidden states
             # Though that's not through between layers so the layers use as input the output of the previous layer
@@ -428,7 +428,9 @@ class _GroundingDinoMultiscaleDeformableAttention(torch.nn.Module):
         # batch_size, num_queries, n_heads, n_levels, n_points, 2
         num_coordinates = reference_points.shape[-1]
         if num_coordinates == 2:
-            offset_normalizer = 0.5 * torch.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
+            offset_normalizer = 0.5 * torch.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1).to(
+                sampling_offsets.dtype
+            )
             sampling_grids = (
                 2 * reference_points[:, :, None, :, None, :]
                 - 1
@@ -525,7 +527,7 @@ class _GroundingDinoBiMultiHeadAttention(torch.nn.Module):
         if text_attention_mask is not None:
             text_attention_mask = text_attention_mask[:, None, None, :].repeat(1, self.num_heads, 1, 1).flatten(0, 1)
             # RBLN FIX: bool tensor to float tensor
-            mask = text_attention_mask * torch.finfo(torch.float16).min
+            mask = text_attention_mask * torch.finfo(attn_weights.dtype).min
             attn_weights = attn_weights + mask
 
         vision_attn_weights = attn_weights.softmax(dim=-1)

--- a/src/optimum/rbln/transformers/models/pixtral/pixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/pixtral/pixtral_architecture.py
@@ -63,7 +63,7 @@ class PixtralAttention(nn.Module):
 
         attn_weights = torch.matmul(query_states, key_states.transpose(3, 4)) * self.scaling
         attn_weights = attn_weights + attention_mask
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
         attn_output = torch.matmul(attn_weights, value_states)
         attn_output = attn_output.transpose(1, 3)
 

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/qwen2_5_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/qwen2_5_vl_architecture.py
@@ -1,11 +1,19 @@
-import math
-
 import torch
 import torch.nn as nn
 from transformers import PreTrainedModel
 
-from ..decoderonly.decoderonly_architecture import DecoderOnlyWrapper, apply_rotary_pos_emb
+from ..decoderonly.decoderonly_architecture import DecoderOnlyWrapper, rotate_half
 from .configuration_qwen2_5_vl import RBLNQwen2_5_VisionTransformerPretrainedModelConfig
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    # Mirrors HF `apply_rotary_pos_emb_vision`: rotate in fp32 and round once.
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.float(), sin.float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
 
 
 class Qwen2_5_VisionTransformerWrapper(nn.Module):
@@ -93,7 +101,7 @@ class Qwen2_5_VLVisionFullAttention(nn.Module):
         self.head_dim = getattr(model, "head_dim", model.proj.in_features // model.num_heads)
         self.qkv = model.qkv
         self.proj = model.proj
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -108,11 +116,11 @@ class Qwen2_5_VLVisionFullAttention(nn.Module):
         )
 
         cos, sin = position_embeddings
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
 
         attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scale
         attn_weights = attn_weights + attn_masks
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=hidden_states.dtype)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
         attn_output = torch.matmul(attn_weights, v)
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)
@@ -133,7 +141,7 @@ class Qwen2_5_VLVisionWindowAttention(nn.Module):
         self.qkv = model.qkv
         self.proj = model.proj
         self.window_seq_len = window_seq_len
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -158,12 +166,12 @@ class Qwen2_5_VLVisionWindowAttention(nn.Module):
         cos, sin = position_embeddings
         cos = cos.reshape(num_windows, 1, seq_length // num_windows, -1)
         sin = sin.reshape(num_windows, 1, seq_length // num_windows, -1)
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
 
         attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scale
 
         attn_weights = attn_weights + attn_masks
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
         attn_output = torch.matmul(attn_weights, v)
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)

--- a/src/optimum/rbln/transformers/models/qwen2_vl/qwen2_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/qwen2_vl_architecture.py
@@ -1,14 +1,22 @@
-import math
-
 import torch
 import torch.nn as nn
 from transformers import PreTrainedModel
 
 from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyWrapper,
-    apply_rotary_pos_emb,
+    rotate_half,
 )
 from .configuration_qwen2_vl import RBLNQwen2VisionTransformerPretrainedModelConfig
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    # Mirrors HF `apply_rotary_pos_emb_vision`: rotate in fp32 and round once.
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.float(), sin.float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
 
 
 class Qwen2VisionTransformerWrapper(nn.Module):
@@ -77,7 +85,7 @@ class VisionAttention(nn.Module):
         self.head_dim = getattr(model, "head_dim", model.proj.in_features // model.num_heads)
         self.qkv = model.qkv
         self.proj = model.proj
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -92,11 +100,11 @@ class VisionAttention(nn.Module):
         )
 
         cos, sin = position_embeddings
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
 
         attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scale
         attn_weights = attn_weights + attn_masks
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
         attn_output = torch.matmul(attn_weights, v)
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)

--- a/src/optimum/rbln/transformers/models/qwen3_5/qwen3_5_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/qwen3_5_architecture.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import math
 
 import torch
 import torch.nn.functional as F
@@ -27,10 +26,20 @@ from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyModel,
     DecoderOnlyWrapper,
     RotaryEmbedding,
-    apply_rotary_pos_emb,
     apply_rotary_pos_emb_partial,
+    rotate_half,
     slice_and_unsqueeze_cos_sin,
 )
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    # Mirrors HF `apply_rotary_pos_emb_vision`: rotate in fp32 and round once.
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.float(), sin.float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
 
 
 class Qwen3_5VisionAttention(nn.Module):
@@ -42,7 +51,7 @@ class Qwen3_5VisionAttention(nn.Module):
         self.head_dim = getattr(model, "head_dim", model.proj.in_features // model.num_heads)
         self.qkv = model.qkv
         self.proj = model.proj
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -56,7 +65,7 @@ class Qwen3_5VisionAttention(nn.Module):
             self.qkv(hidden_states).reshape(1, seq_length, 3, self.num_heads, -1).permute(2, 0, 3, 1, 4).unbind(0)
         )
         cos, sin = position_embeddings
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
         attn_output = nn.functional.scaled_dot_product_attention(
             q,
             k,
@@ -64,7 +73,7 @@ class Qwen3_5VisionAttention(nn.Module):
             attn_mask=attn_mask,
             dropout_p=0.0,
             is_causal=False,
-            scale=self.scale.item(),
+            scale=self.scale,
         )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)
@@ -110,7 +119,6 @@ class Qwen3_5VisionModelWrapper(nn.Module):
         sin: torch.Tensor,
     ) -> torch.Tensor:
         attn_mask = (1.0 - attn_mask) * torch.finfo(hidden_states.dtype).min
-        cos, sin = cos.to(hidden_states.dtype), sin.to(hidden_states.dtype)
         for block in self.blocks:
             hidden_states = block(hidden_states, attn_mask, (cos, sin))
         return self.merger(hidden_states)
@@ -388,8 +396,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         if "prefill" in self._phase:
             # Triangular masks built
             _cshape = (1, 1, 1, self.chunk_size, self.chunk_size)
-            chunk_tril_incl = torch.tril(torch.ones(_cshape, device=query.device, dtype=query.dtype), diagonal=0)
-            chunk_tril_strict = torch.tril(torch.ones(_cshape, device=query.device, dtype=query.dtype), diagonal=-1)
+            chunk_tril_incl = torch.tril(torch.ones(_cshape, device=query.device, dtype=torch.float32), diagonal=0)
+            chunk_tril_strict = torch.tril(torch.ones(_cshape, device=query.device, dtype=torch.float32), diagonal=-1)
             core_attn_out, new_recurrent_state = rbln_chunk_gated_delta_rule(
                 query,
                 key,

--- a/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -24,7 +23,7 @@ from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyForCausalLM,
     DecoderOnlyModel,
     DecoderOnlyWrapper,
-    apply_rotary_pos_emb,
+    rotate_half,
     slice_and_unsqueeze_cos_sin,
 )
 from .configuration_qwen3_vl import RBLNQwen3VLVisionModelConfig
@@ -32,6 +31,16 @@ from .configuration_qwen3_vl import RBLNQwen3VLVisionModelConfig
 
 if TYPE_CHECKING:
     from .configuration_qwen3_vl import RBLNQwen3VLForConditionalGenerationConfig
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    # Mirrors HF `apply_rotary_pos_emb_vision`: rotate in fp32 and round once.
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.float(), sin.float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
 
 
 class Qwen3VLVisionModelWrapper(nn.Module):
@@ -112,7 +121,7 @@ class Qwen3VLVisionAttention(nn.Module):
         self.head_dim = getattr(model, "head_dim", model.proj.in_features // model.num_heads)
         self.qkv = model.qkv
         self.proj = model.proj
-        self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
+        self.scale = self.head_dim**-0.5
 
     def forward(
         self,
@@ -126,7 +135,7 @@ class Qwen3VLVisionAttention(nn.Module):
             self.qkv(hidden_states).reshape(1, seq_length, 3, self.num_heads, -1).permute(2, 0, 3, 1, 4).unbind(0)
         )
         cos, sin = position_embeddings
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
         attn_output = nn.functional.scaled_dot_product_attention(
             q,
             k,
@@ -134,7 +143,7 @@ class Qwen3VLVisionAttention(nn.Module):
             attn_mask=attn_mask,
             dropout_p=0.0,
             is_causal=False,
-            scale=self.scale.item(),
+            scale=self.scale,
         )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)

--- a/src/optimum/rbln/transformers/models/t5/t5_architecture.py
+++ b/src/optimum/rbln/transformers/models/t5/t5_architecture.py
@@ -199,19 +199,22 @@ class T5Block(Seq2SeqDecoderLayer):
         self.self_attn_layer_norm = decoder_layer.layer[0].layer_norm
         self.encoder_attn_layer_norm = decoder_layer.layer[1].layer_norm
         self.cross_attn = T5CrossAttention(decoder_layer.layer[1].EncDecAttention)
-        self.ff_layer = decoder_layer.layer[2]
+        self._ff_layer = decoder_layer.layer[2]
+
+    def ff_layer(self, hidden_states):
+        return _clamp_finite(self._ff_layer(hidden_states))
 
     def pre_self_attn_layer_norm(self, hidden_states):
         return self.self_attn_layer_norm(hidden_states)
 
     def post_self_attn_layer_norm(self, hidden_states):
-        return hidden_states
+        return _clamp_finite(hidden_states)
 
     def pre_cross_attn_layer_norm(self, hidden_states):
         return self.encoder_attn_layer_norm(hidden_states)
 
     def post_cross_attn_layer_norm(self, hidden_states):
-        return hidden_states
+        return _clamp_finite(hidden_states)
 
 
 class T5LayerSelfAttention(Seq2SeqSelfAttention):

--- a/src/optimum/rbln/transformers/models/time_series_transformer/time_series_transformers_architecture.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/time_series_transformers_architecture.py
@@ -22,11 +22,15 @@
 # from Rebellions Inc.
 
 
+from types import MethodType
+
 import torch
 from torch import nn
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.utils import logging
+
+from ..bart.bart_architecture import _encoder_layer_forward
 
 
 logger = logging.get_logger(__name__)
@@ -43,6 +47,9 @@ class TimeSeriesTransformersEncoderWrapper(torch.nn.Module):
         super().__init__()
         self.config = model.config
         self.encoder = model.get_encoder()
+        # Same layer layout and data-dependent fp16 clamp guard as BART.
+        for layer in self.encoder.layers:
+            layer.forward = MethodType(_encoder_layer_forward, layer)
         self.num_heads = self.config.decoder_attention_heads
         self.d_kv = self.config.d_model // self.num_heads
         self.cross_k_projects, self.cross_v_projects = self._extract_cross_kv_projects(model.get_decoder().layers)

--- a/src/optimum/rbln/transformers/utils/moe.py
+++ b/src/optimum/rbln/transformers/utils/moe.py
@@ -19,16 +19,17 @@ from torch import Tensor
 def compute_masked_routing_weight_softmax_first(router_logits: Tensor, top_k: int, renormalize: bool) -> Tensor:
     #   renormalize=True : topk → softmax-of-topk → scatter  (post_norm)
     #   renormalize=False: softmax → topk → scatter           (pre_norm)
-    router_logits_t = router_logits.transpose(0, 1)  # [T, E] -> [E, T]
+    # HF routes in fp32 (softmax(..., dtype=torch.float)) and casts the weights back to the logits dtype.
+    router_logits_t = router_logits.transpose(0, 1).to(torch.float32)  # [T, E] -> [E, T]
     if renormalize:
         topk_values, topk_ids = torch.topk(router_logits_t, top_k, dim=0)
         topk_weights = torch.softmax(topk_values, dim=0)
     else:
         routing = torch.softmax(router_logits_t, dim=0)
         topk_weights, topk_ids = torch.topk(routing, top_k, dim=0)
-    masked = torch.zeros_like(router_logits_t, dtype=router_logits.dtype)
+    masked = torch.zeros_like(router_logits_t)
     masked.scatter_(0, topk_ids, topk_weights)
-    return masked  # [E, T]
+    return masked.to(router_logits.dtype)  # [E, T]
 
 
 def compute_masked_routing_weight_topk_first(router_logits: Tensor, top_k: int) -> Tensor:


### PR DESCRIPTION
## Summary

Until now every compiled graph was forced into a single dtype, so the explicit casts HF performs (`.to(torch.float32)`, `.to(input_dtype)`, `torch.tensor(x, dtype=...)`) were dead weight and `*_architecture.py` dropped them, or in one case inverted them. With the compiler honoring per-op dtypes (`comp_dtype=auto`), each of those spots now computes something different from HF under fp16/bf16.

This PR re-audits the graph code we re-implement against transformers 5.8.1 and restores the HF form. Scope:

- Only `*_architecture.py` (graph code) changes. `modeling_*.py`, compile input signatures, and host-side casts are untouched.
- Code that reuses HF `nn.Module`s as-is (RMSNorm, MLP, q/k norm, projectors) already carries HF's casts and is not touched.
- Math inside `rbln_custom_ops` (attention, MoE kernel) is out of scope; only what feeds those ops is changed.

## Changes

### Text rotary (all decoder-only models)
HF `LlamaRotaryEmbedding` returns `cos.to(x.dtype)`, `sin.to(x.dtype)` and `apply_rotary_pos_emb` rotates in that dtype. #259 flipped this: cos/sin stayed fp32, q/k were promoted to fp32 for the rotation and cast back. Restored the HF form, which also removes an fp32 island from every layer.

### Embedding normalizer (Gemma, Gemma2 with `use_inputs_embeds`)
HF multiplies by `torch.tensor(hidden_size**0.5, dtype=embed dtype)`, a constant rounded to the activation dtype (sqrt(3072) becomes 55.5 in bf16). We multiplied by the exact python float. Applied at the base multiply site in `DecoderOnlyModel.forward` so every `hidden_multiplier` override benefits; a multiplier of 1 is left alone.

### Vision towers (Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3.5, EXAONE-4.5)
- HF `apply_rotary_pos_emb_vision` upcasts q/k/cos/sin to fp32, rotates, and rounds once. We used the text-side `apply_rotary_pos_emb`, which rotates in the graph dtype. Each family's architecture file now carries its own `apply_rotary_pos_emb_vision` mirroring the HF one, as HF does per model.
- Softmax in fp32 then cast to the query dtype where we compute attention with plain torch (Qwen2-VL, Qwen2.5-VL), as HF eager does.
- SDPA/eager scale as the exact python float `head_dim**-0.5` like HF, instead of a `rbln_config.dtype` tensor whose `.item()` is the rounded value (0.5% off for head_dim 72 in bf16).

### MoE router (`compute_masked_routing_weight_softmax_first`)
HF runs `softmax(router_logits, dtype=torch.float)`, topk and renormalization in fp32 and casts the weights back to the logits dtype. Ours ran in the logits dtype. Now fp32 with the trailing cast, which is also what the MoE custom op expects. Applies to Mixtral, Qwen2-MoE, Qwen3-MoE, Qwen3-VL-MoE and Gemma4. The GPT-OSS topk-first helper already matched HF and is unchanged.

### Qwen3.5 GatedDeltaNet
#710 restored the fp32 kernel but the triangular masks were still built in `query.dtype`; in bf16 that makes `incr @ tril` a mixed-dtype matmul at trace time. Masks are now fp32 like HF's.

### Pixtral
HF casts the fp32 softmax back to `query.dtype` before `P @ V`. Ours left it fp32, which is a mixed-dtype matmul in fp16.

### GroundingDINO
- `0.5 * int64` promoted the deformable-attention sampling grid to fp32, so `grid_sample` on fp16 values fails. HF keeps the divisor integer; we now cast it to the offsets' dtype.
- The fp32 sine position embedding went straight into the fp16 `reference_points_head`; cast to the hidden dtype first (the encoder side got the same fix in #673).
- Two mask constants were hard-coded `torch.finfo(torch.float16).min`; now derived from the actual dtype like HF.

### T5 decoder, TimeSeriesTransformer encoder
HF clamps fp16 activations with a data-dependent `isinf(...).any()` guard that cannot be traced. #673 replaced it with the dtype-gated `_clamp_finite` for the T5 encoder and BART. This applies the same to the T5 decoder block (after self-attn, cross-attn and FF, where HF clamps) and reuses BART's patched encoder-layer forward for TimeSeriesTransformer, whose layer layout is identical. Identity on finite activations; only fp16 overflow behaves differently (clamped instead of propagating inf).

## Deliberately not changed
- **LoRA** adapters stay in the base weight dtype. peft's default computes the LoRA path in the adapter's own dtype (fp32 after `autocast_adapter_dtype`), but the stored adapter dtype alone cannot tell peft's two modes apart, so the existing behavior is kept.
- **SWA decode mask** (`torch.where(..., 0.0, 1.0)`) is our own custom-op input with no HF counterpart; left as is.
- **GPT-OSS `alpha`/`limit`** are materialized in the graph dtype and handed to the MoE kernel as scalars; HF uses python floats. Whether the kernel accepts an fp32 scalar needs a compiler-side check.
- `colpali_architecture.py` has the Gemma normalizer issue but is dead code (ColPali runs through the PaliGemma submodule).

## Testing
- CPU, fp16 and bf16: text rotary, all five vision rotary helpers, and MoE routing are bit-identical to the HF functions.
- NPU (RBLN-CA25, rebel-compiler 0.11.3.dev58), compiled with `dtype=float16`, compared against HF fp16 on CPU:

| model | max abs logit diff | cosine | argmax |
| --- | --- | --- | --- |
| tiny-random-LlamaForCausalLM | 0.0007 | 0.999997 | same |
| tiny-random-Gemma2ForCausalLM | 0.0029 | 0.999973 | same |
| tiny-random-Qwen2VLForConditionalGeneration (image + text) | 0.0008 | 0.999990 | same |
| google-t5/t5-small | greedy output identical | | |

- Not device-verified: GroundingDINO (the tiny checkpoint fails HF's `tie_weights_keys` check in transformers 5.8.1 before export), MoE routing (Mixtral-tiny has no weights in the offline cache), Pixtral, EXAONE-4.5 vision, TimeSeriesTransformer.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
