### PR TITLE
model: moe drop redundant expert weight copies and release HF fused gate_up_proj

### DIFF
--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -549,11 +549,11 @@ class Gemma4Experts(nn.Module):
 
         gate_w_op = gate_w.contiguous()
         up_w_op = up_w.contiguous()
-        down_w_op = down_w.contiguous().clone()
+        down_w_op = down_w.detach()
 
-        self.gate_proj = nn.Linear(self.hidden_size, self.num_experts * self.intermediate_size, bias=False)
-        self.up_proj = nn.Linear(self.hidden_size, self.num_experts * self.intermediate_size, bias=False)
-        self.down_proj = nn.Linear(self.num_experts * self.intermediate_size, self.hidden_size, bias=False)
+        self.gate_proj = nn.Linear(1, 1, bias=False)
+        self.up_proj = nn.Linear(1, 1, bias=False)
+        self.down_proj = nn.Linear(1, 1, bias=False)
         self.gate_proj.weight.data = gate_w_op
         self.up_proj.weight.data = up_w_op
         self.down_proj.weight.data = down_w_op

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -552,12 +552,9 @@ class Gemma4Experts(nn.Module):
         experts.gate_up_proj = None
         down_w_op = down_w.detach()
 
-        self.gate_proj = nn.Linear(1, 1, bias=False)
-        self.up_proj = nn.Linear(1, 1, bias=False)
-        self.down_proj = nn.Linear(1, 1, bias=False)
-        self.gate_proj.weight.data = gate_w_op
-        self.up_proj.weight.data = up_w_op
-        self.down_proj.weight.data = down_w_op
+        self.register_buffer("gate_proj_weight", gate_w_op)
+        self.register_buffer("up_proj_weight", up_w_op)
+        self.register_buffer("down_proj_weight", down_w_op)
 
     def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         masked_routing_weight = compute_masked_routing_weight_softmax_first(
@@ -567,9 +564,9 @@ class Gemma4Experts(nn.Module):
 
         return torch.ops.rbln_custom_ops.custom_moe_glu(
             hidden_states=hidden_states,
-            gate_proj_weight=self.gate_proj.weight,
-            up_proj_weight=self.up_proj.weight,
-            down_proj_weight=self.down_proj.weight,
+            gate_proj_weight=self.gate_proj_weight,
+            up_proj_weight=self.up_proj_weight,
+            down_proj_weight=self.down_proj_weight,
             masked_routing_weight=masked_routing_weight,
             hidden_act="gelu",
         )

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -549,6 +549,7 @@ class Gemma4Experts(nn.Module):
 
         gate_w_op = gate_w.contiguous()
         up_w_op = up_w.contiguous()
+        experts.gate_up_proj = None
         down_w_op = down_w.detach()
 
         self.gate_proj = nn.Linear(1, 1, bias=False)

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from transformers import PreTrainedModel
 from transformers.activations import ACT2FN
 
-from ...utils.moe import compute_masked_routing_weight_softmax_first
+from ...utils.moe import compute_masked_routing_weight_softmax_first, split_fused_experts
 from ..decoderonly.configuration_decoderonly import RBLNLoRAConfig
 from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyAttention,
@@ -540,21 +540,12 @@ class Gemma4Experts(nn.Module):
         self.top_k = int(router.config.top_k_experts)
         self.norm_topk_prob = True
 
-        gate_up = experts.gate_up_proj
-        gate_w = gate_up[:, : self.intermediate_size, :]
-        up_w = gate_up[:, self.intermediate_size :, :]
-        down_w = experts.down_proj
-
         self.per_expert_scale = router.per_expert_scale.detach().clone().unsqueeze(1)
 
-        gate_w_op = gate_w.contiguous()
-        up_w_op = up_w.contiguous()
-        experts.gate_up_proj = None
-        down_w_op = down_w.detach()
-
-        self.register_buffer("gate_proj_weight", gate_w_op)
-        self.register_buffer("up_proj_weight", up_w_op)
-        self.register_buffer("down_proj_weight", down_w_op)
+        gate, up, down = split_fused_experts(experts)
+        self.register_buffer("gate_proj_weight", gate)
+        self.register_buffer("up_proj_weight", up)
+        self.register_buffer("down_proj_weight", down)
 
     def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/gpt_oss/gpt_oss_architecture.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/gpt_oss_architecture.py
@@ -87,22 +87,27 @@ class RBLNGptOssExperts(nn.Module):
 
         self.register_buffer(
             "gate_proj_blocks",
-            gate_up_blocks[:, ::2, :, :].reshape(self.num_experts, self.intermediate_size, -1),
+            gate_up_blocks[:, ::2, :, :].reshape(self.num_experts, self.intermediate_size, -1).contiguous(),
         )
-        self.register_buffer("gate_proj_scales", gate_up_scales[:, ::2, :])
+        self.register_buffer("gate_proj_scales", gate_up_scales[:, ::2, :].contiguous())
         self.register_buffer(
             "gate_proj_bias",
-            model.gate_up_proj_bias.data[:, ::2].reshape(self.num_experts, self.intermediate_size),
+            model.gate_up_proj_bias.data[:, ::2].reshape(self.num_experts, self.intermediate_size).contiguous(),
         )
 
         self.register_buffer(
             "up_proj_blocks",
-            gate_up_blocks[:, 1::2, :, :].reshape(self.num_experts, self.intermediate_size, -1),
+            gate_up_blocks[:, 1::2, :, :].reshape(self.num_experts, self.intermediate_size, -1).contiguous(),
         )
-        self.register_buffer("up_proj_scales", gate_up_scales[:, 1::2, :])
+        self.register_buffer("up_proj_scales", gate_up_scales[:, 1::2, :].contiguous())
         self.register_buffer(
-            "up_proj_bias", model.gate_up_proj_bias.data[:, 1::2].reshape(self.num_experts, self.intermediate_size)
+            "up_proj_bias",
+            model.gate_up_proj_bias.data[:, 1::2].reshape(self.num_experts, self.intermediate_size).contiguous(),
         )
+        if hasattr(model, "gate_up_proj_blocks"):
+            model.gate_up_proj_blocks = None
+        else:
+            model.gate_up_proj = None
 
         self.register_buffer("down_proj_blocks", down_blocks.reshape(self.num_experts, self.hidden_size, -1))
         self.register_buffer("down_proj_scales", down_scales)

--- a/src/optimum/rbln/transformers/models/gpt_oss/gpt_oss_architecture.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/gpt_oss_architecture.py
@@ -50,6 +50,25 @@ class RBLNGptOssTopKRouter(nn.Module):
         return F.linear(hidden_states, self.weight, self.bias)  # (seq_len, num_experts)
 
 
+def split_interleaved_experts(model: nn.Module, gate_up_blocks: torch.Tensor, gate_up_scales: torch.Tensor):
+    # mxfp4 GPT-OSS interleaves gate|up along dim 1 (even rows gate, odd rows up); custom_moe_glu_mxfp4 takes
+    # them separately, so the strided halves are copied to be contiguous. The fused source is released
+    # afterwards: the HF experts module is not run once wrapped, and keeping it would double host memory.
+    num_experts, intermediate_size = model.num_experts, model.intermediate_size
+    bias = model.gate_up_proj_bias.data
+    gate_blocks = gate_up_blocks[:, ::2, :, :].reshape(num_experts, intermediate_size, -1).contiguous()
+    gate_scales = gate_up_scales[:, ::2, :].contiguous()
+    gate_bias = bias[:, ::2].reshape(num_experts, intermediate_size).contiguous()
+    up_blocks = gate_up_blocks[:, 1::2, :, :].reshape(num_experts, intermediate_size, -1).contiguous()
+    up_scales = gate_up_scales[:, 1::2, :].contiguous()
+    up_bias = bias[:, 1::2].reshape(num_experts, intermediate_size).contiguous()
+    if hasattr(model, "gate_up_proj_blocks"):
+        model.gate_up_proj_blocks = None
+    else:
+        model.gate_up_proj = None
+    return gate_blocks, gate_scales, gate_bias, up_blocks, up_scales, up_bias
+
+
 class RBLNGptOssExperts(nn.Module):
     def __init__(self, model, top_k: int | None = None):
         super().__init__()
@@ -85,29 +104,15 @@ class RBLNGptOssExperts(nn.Module):
             down_blocks = model.down_proj.data
             down_scales = model.down_proj_scales.data
 
-        self.register_buffer(
-            "gate_proj_blocks",
-            gate_up_blocks[:, ::2, :, :].reshape(self.num_experts, self.intermediate_size, -1).contiguous(),
+        gate_blocks, gate_scales, gate_bias, up_blocks, up_scales, up_bias = split_interleaved_experts(
+            model, gate_up_blocks, gate_up_scales
         )
-        self.register_buffer("gate_proj_scales", gate_up_scales[:, ::2, :].contiguous())
-        self.register_buffer(
-            "gate_proj_bias",
-            model.gate_up_proj_bias.data[:, ::2].reshape(self.num_experts, self.intermediate_size).contiguous(),
-        )
-
-        self.register_buffer(
-            "up_proj_blocks",
-            gate_up_blocks[:, 1::2, :, :].reshape(self.num_experts, self.intermediate_size, -1).contiguous(),
-        )
-        self.register_buffer("up_proj_scales", gate_up_scales[:, 1::2, :].contiguous())
-        self.register_buffer(
-            "up_proj_bias",
-            model.gate_up_proj_bias.data[:, 1::2].reshape(self.num_experts, self.intermediate_size).contiguous(),
-        )
-        if hasattr(model, "gate_up_proj_blocks"):
-            model.gate_up_proj_blocks = None
-        else:
-            model.gate_up_proj = None
+        self.register_buffer("gate_proj_blocks", gate_blocks)
+        self.register_buffer("gate_proj_scales", gate_scales)
+        self.register_buffer("gate_proj_bias", gate_bias)
+        self.register_buffer("up_proj_blocks", up_blocks)
+        self.register_buffer("up_proj_scales", up_scales)
+        self.register_buffer("up_proj_bias", up_bias)
 
         self.register_buffer("down_proj_blocks", down_blocks.reshape(self.num_experts, self.hidden_size, -1))
         self.register_buffer("down_proj_scales", down_scales)

--- a/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
@@ -40,7 +40,7 @@ class MixtralSparseMoeBlock(nn.Module):
         self.top_k = model.top_k
         gate_weight = model.gate.weight
         gate = nn.Linear(gate_weight.shape[1], gate_weight.shape[0], bias=False)
-        gate.weight = nn.Parameter(gate_weight.detach().clone())
+        gate.weight = model.gate.weight
         self.gate = gate
         self.experts = MixtralBlockSparseTop2MLP(model.experts, self.top_k)
 
@@ -60,11 +60,11 @@ class MixtralBlockSparseTop2MLP(nn.Module):
         self.top_k = top_k
 
         # Fused MixtralExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
-        gate_up = experts.gate_up_proj.detach().clone()
+        gate_up = experts.gate_up_proj.detach()
         intermediate_size = gate_up.shape[1] // 2
         self.w1_weight = nn.Parameter(gate_up[:, :intermediate_size, :].contiguous())
         self.w3_weight = nn.Parameter(gate_up[:, intermediate_size:, :].contiguous())
-        self.w2_weight = nn.Parameter(experts.down_proj.detach().clone().contiguous())
+        self.w2_weight = nn.Parameter(experts.down_proj.detach())
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
@@ -16,7 +16,7 @@
 import torch
 from torch import nn
 
-from ...utils.moe import compute_masked_routing_weight_softmax_first
+from ...utils.moe import compute_masked_routing_weight_softmax_first, split_fused_experts
 from ..decoderonly.configuration_decoderonly import RBLNLoRAConfig
 from ..decoderonly.decoderonly_architecture import DecoderOnlyAttention, DecoderOnlyLayer, DecoderOnlyWrapper
 
@@ -60,12 +60,10 @@ class MixtralBlockSparseTop2MLP(nn.Module):
         self.top_k = top_k
 
         # Fused MixtralExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
-        gate_up = experts.gate_up_proj.detach()
-        intermediate_size = gate_up.shape[1] // 2
-        self.w1_weight = nn.Parameter(gate_up[:, :intermediate_size, :].contiguous())
-        self.w3_weight = nn.Parameter(gate_up[:, intermediate_size:, :].contiguous())
-        experts.gate_up_proj = None
-        self.w2_weight = nn.Parameter(experts.down_proj.detach())
+        gate, up, down = split_fused_experts(experts)
+        self.w1_weight = nn.Parameter(gate)
+        self.w3_weight = nn.Parameter(up)
+        self.w2_weight = nn.Parameter(down)
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
@@ -64,6 +64,7 @@ class MixtralBlockSparseTop2MLP(nn.Module):
         intermediate_size = gate_up.shape[1] // 2
         self.w1_weight = nn.Parameter(gate_up[:, :intermediate_size, :].contiguous())
         self.w3_weight = nn.Parameter(gate_up[:, intermediate_size:, :].contiguous())
+        experts.gate_up_proj = None
         self.w2_weight = nn.Parameter(experts.down_proj.detach())
 
     def forward(self, x, router_logits):

--- a/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
@@ -79,13 +79,10 @@ class Qwen2MoeMLP(nn.Module):
         self.num_experts = experts.num_experts
         intermediate_dim = experts.intermediate_dim
         gate_up = experts.gate_up_proj.detach()
-        self.gate_proj = nn.Linear(1, 1, bias=False)
-        self.up_proj = nn.Linear(1, 1, bias=False)
-        self.down_proj = nn.Linear(1, 1, bias=False)
-        self.gate_proj.weight = nn.Parameter(gate_up[:, :intermediate_dim, :].contiguous())
-        self.up_proj.weight = nn.Parameter(gate_up[:, intermediate_dim:, :].contiguous())
+        self.register_buffer("gate_proj_weight", gate_up[:, :intermediate_dim, :].contiguous())
+        self.register_buffer("up_proj_weight", gate_up[:, intermediate_dim:, :].contiguous())
         experts.gate_up_proj = None
-        self.down_proj.weight = nn.Parameter(experts.down_proj.detach())
+        self.register_buffer("down_proj_weight", experts.down_proj.detach())
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(
@@ -93,9 +90,9 @@ class Qwen2MoeMLP(nn.Module):
         )
         return torch.ops.rbln_custom_ops.custom_moe_glu(
             hidden_states=x,
-            gate_proj_weight=self.gate_proj.weight,
-            up_proj_weight=self.up_proj.weight,
-            down_proj_weight=self.down_proj.weight,
+            gate_proj_weight=self.gate_proj_weight,
+            up_proj_weight=self.up_proj_weight,
+            down_proj_weight=self.down_proj_weight,
             masked_routing_weight=masked_routing_weight,
             hidden_act="silu",
         )

--- a/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
@@ -16,7 +16,7 @@
 import torch
 from torch import nn
 
-from ...utils.moe import compute_masked_routing_weight_softmax_first
+from ...utils.moe import compute_masked_routing_weight_softmax_first, split_fused_experts
 from ..decoderonly.configuration_decoderonly import RBLNLoRAConfig
 from ..decoderonly.decoderonly_architecture import DecoderOnlyAttention, DecoderOnlyLayer, DecoderOnlyWrapper
 
@@ -77,12 +77,10 @@ class Qwen2MoeMLP(nn.Module):
 
         # Fused Qwen2MoeExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
         self.num_experts = experts.num_experts
-        intermediate_dim = experts.intermediate_dim
-        gate_up = experts.gate_up_proj.detach()
-        self.register_buffer("gate_proj_weight", gate_up[:, :intermediate_dim, :].contiguous())
-        self.register_buffer("up_proj_weight", gate_up[:, intermediate_dim:, :].contiguous())
-        experts.gate_up_proj = None
-        self.register_buffer("down_proj_weight", experts.down_proj.detach())
+        gate, up, down = split_fused_experts(experts)
+        self.register_buffer("gate_proj_weight", gate)
+        self.register_buffer("up_proj_weight", up)
+        self.register_buffer("down_proj_weight", down)
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
@@ -84,6 +84,7 @@ class Qwen2MoeMLP(nn.Module):
         self.down_proj = nn.Linear(1, 1, bias=False)
         self.gate_proj.weight = nn.Parameter(gate_up[:, :intermediate_dim, :].contiguous())
         self.up_proj.weight = nn.Parameter(gate_up[:, intermediate_dim:, :].contiguous())
+        experts.gate_up_proj = None
         self.down_proj.weight = nn.Parameter(experts.down_proj.detach())
 
     def forward(self, x, router_logits):

--- a/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
@@ -47,7 +47,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         self.norm_topk_prob = model.gate.norm_topk_prob
         gate_weight = model.gate.weight
         gate = nn.Linear(gate_weight.shape[1], gate_weight.shape[0], bias=False)
-        gate.weight = nn.Parameter(gate_weight.detach().clone())
+        gate.weight = model.gate.weight
         self.gate = gate
         self.shared_expert = model.shared_expert
         self.shared_expert_gate = model.shared_expert_gate
@@ -78,13 +78,13 @@ class Qwen2MoeMLP(nn.Module):
         # Fused Qwen2MoeExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
         self.num_experts = experts.num_experts
         intermediate_dim = experts.intermediate_dim
-        gate_up = experts.gate_up_proj.detach().clone()
+        gate_up = experts.gate_up_proj.detach()
         self.gate_proj = nn.Linear(1, 1, bias=False)
         self.up_proj = nn.Linear(1, 1, bias=False)
         self.down_proj = nn.Linear(1, 1, bias=False)
         self.gate_proj.weight = nn.Parameter(gate_up[:, :intermediate_dim, :].contiguous())
         self.up_proj.weight = nn.Parameter(gate_up[:, intermediate_dim:, :].contiguous())
-        self.down_proj.weight = nn.Parameter(experts.down_proj.detach().clone().contiguous())
+        self.down_proj.weight = nn.Parameter(experts.down_proj.detach())
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
@@ -16,7 +16,7 @@
 import torch
 from torch import nn
 
-from ...utils.moe import compute_masked_routing_weight_softmax_first
+from ...utils.moe import compute_masked_routing_weight_softmax_first, split_fused_experts
 from ..decoderonly.configuration_decoderonly import RBLNLoRAConfig
 from ..decoderonly.decoderonly_architecture import DecoderOnlyAttention, DecoderOnlyLayer, DecoderOnlyWrapper
 
@@ -86,16 +86,10 @@ class Qwen3MoeMLP(nn.Module):
         self.num_experts = experts.num_experts
         self.hidden_size = experts.hidden_dim
         self.intermediate_size = experts.intermediate_dim
-        gate_up = experts.gate_up_proj.detach()
-        intermediate_size = gate_up.shape[1] // 2
-        gate_stack = gate_up[:, :intermediate_size, :].contiguous()
-        up_stack = gate_up[:, intermediate_size:, :].contiguous()
-        experts.gate_up_proj = None
-        down_stack = experts.down_proj.detach()
-
-        self.register_buffer("gate_proj_weight", gate_stack)
-        self.register_buffer("up_proj_weight", up_stack)
-        self.register_buffer("down_proj_weight", down_stack)
+        gate, up, down = split_fused_experts(experts)
+        self.register_buffer("gate_proj_weight", gate)
+        self.register_buffer("up_proj_weight", up)
+        self.register_buffer("down_proj_weight", down)
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
@@ -90,6 +90,7 @@ class Qwen3MoeMLP(nn.Module):
         intermediate_size = gate_up.shape[1] // 2
         gate_stack = gate_up[:, :intermediate_size, :].contiguous()
         up_stack = gate_up[:, intermediate_size:, :].contiguous()
+        experts.gate_up_proj = None
         down_stack = experts.down_proj.detach()
 
         self.gate_proj = nn.Linear(1, 1, bias=False)

--- a/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
@@ -60,7 +60,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.norm_topk_prob = model.gate.norm_topk_prob
         gate_weight = model.gate.weight
         gate = nn.Linear(gate_weight.shape[1], gate_weight.shape[0], bias=False)
-        gate.weight = nn.Parameter(gate_weight.detach().clone())
+        gate.weight = model.gate.weight
         self.gate = gate
         self.experts = Qwen3MoeMLP(model.experts, self.top_k, self.norm_topk_prob)
 
@@ -86,15 +86,15 @@ class Qwen3MoeMLP(nn.Module):
         self.num_experts = experts.num_experts
         self.hidden_size = experts.hidden_dim
         self.intermediate_size = experts.intermediate_dim
-        gate_up = experts.gate_up_proj.detach().clone()
+        gate_up = experts.gate_up_proj.detach()
         intermediate_size = gate_up.shape[1] // 2
         gate_stack = gate_up[:, :intermediate_size, :].contiguous()
         up_stack = gate_up[:, intermediate_size:, :].contiguous()
-        down_stack = experts.down_proj.detach().clone().contiguous()
+        down_stack = experts.down_proj.detach()
 
-        self.gate_proj = nn.Linear(self.hidden_size, self.num_experts * self.intermediate_size, bias=False)
-        self.up_proj = nn.Linear(self.hidden_size, self.num_experts * self.intermediate_size, bias=False)
-        self.down_proj = nn.Linear(self.num_experts * self.intermediate_size, self.hidden_size, bias=False)
+        self.gate_proj = nn.Linear(1, 1, bias=False)
+        self.up_proj = nn.Linear(1, 1, bias=False)
+        self.down_proj = nn.Linear(1, 1, bias=False)
         self.gate_proj.weight.data = gate_stack
         self.up_proj.weight.data = up_stack
         self.down_proj.weight.data = down_stack

--- a/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
@@ -93,12 +93,9 @@ class Qwen3MoeMLP(nn.Module):
         experts.gate_up_proj = None
         down_stack = experts.down_proj.detach()
 
-        self.gate_proj = nn.Linear(1, 1, bias=False)
-        self.up_proj = nn.Linear(1, 1, bias=False)
-        self.down_proj = nn.Linear(1, 1, bias=False)
-        self.gate_proj.weight.data = gate_stack
-        self.up_proj.weight.data = up_stack
-        self.down_proj.weight.data = down_stack
+        self.register_buffer("gate_proj_weight", gate_stack)
+        self.register_buffer("up_proj_weight", up_stack)
+        self.register_buffer("down_proj_weight", down_stack)
 
     def forward(self, x, router_logits):
         masked_routing_weight = compute_masked_routing_weight_softmax_first(
@@ -106,9 +103,9 @@ class Qwen3MoeMLP(nn.Module):
         )
         return torch.ops.rbln_custom_ops.custom_moe_glu(
             hidden_states=x,
-            gate_proj_weight=self.gate_proj.weight,
-            up_proj_weight=self.up_proj.weight,
-            down_proj_weight=self.down_proj.weight,
+            gate_proj_weight=self.gate_proj_weight,
+            up_proj_weight=self.up_proj_weight,
+            down_proj_weight=self.down_proj_weight,
             masked_routing_weight=masked_routing_weight,
             hidden_act="silu",
         )

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
@@ -83,17 +83,13 @@ class Qwen3VLMoeMLP(nn.Module):
         self.top_k = top_k
         self.norm_topk_prob = True
 
-        self.gate_proj = nn.Linear(1, 1, bias=False)
-        self.up_proj = nn.Linear(1, 1, bias=False)
-        self.down_proj = nn.Linear(1, 1, bias=False)
-
         # Fused Qwen3VLMoeTextExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
         intermediate_dim = experts.intermediate_dim
         gate_up = experts.gate_up_proj.detach()
-        self.gate_proj.weight = nn.Parameter(gate_up[:, :intermediate_dim, :].contiguous())
-        self.up_proj.weight = nn.Parameter(gate_up[:, intermediate_dim:, :].contiguous())
+        self.register_buffer("gate_proj_weight", gate_up[:, :intermediate_dim, :].contiguous())
+        self.register_buffer("up_proj_weight", gate_up[:, intermediate_dim:, :].contiguous())
         experts.gate_up_proj = None
-        self.down_proj.weight = nn.Parameter(experts.down_proj.detach())
+        self.register_buffer("down_proj_weight", experts.down_proj.detach())
 
     def forward(self, x: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         masked_routing_weight = compute_masked_routing_weight_softmax_first(
@@ -101,9 +97,9 @@ class Qwen3VLMoeMLP(nn.Module):
         )
         return torch.ops.rbln_custom_ops.custom_moe_glu(
             hidden_states=x,
-            gate_proj_weight=self.gate_proj.weight,
-            up_proj_weight=self.up_proj.weight,
-            down_proj_weight=self.down_proj.weight,
+            gate_proj_weight=self.gate_proj_weight,
+            up_proj_weight=self.up_proj_weight,
+            down_proj_weight=self.down_proj_weight,
             masked_routing_weight=masked_routing_weight,
             hidden_act="silu",
         )

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
@@ -92,6 +92,7 @@ class Qwen3VLMoeMLP(nn.Module):
         gate_up = experts.gate_up_proj.detach()
         self.gate_proj.weight = nn.Parameter(gate_up[:, :intermediate_dim, :].contiguous())
         self.up_proj.weight = nn.Parameter(gate_up[:, intermediate_dim:, :].contiguous())
+        experts.gate_up_proj = None
         self.down_proj.weight = nn.Parameter(experts.down_proj.detach())
 
     def forward(self, x: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
@@ -16,7 +16,7 @@
 import torch
 import torch.nn as nn
 
-from ...utils.moe import compute_masked_routing_weight_softmax_first
+from ...utils.moe import compute_masked_routing_weight_softmax_first, split_fused_experts
 from ..decoderonly.configuration_lora import RBLNLoRAConfig
 from ..decoderonly.decoderonly_architecture import DecoderOnlyAttention, DecoderOnlyLayer
 from ..qwen3_vl.qwen3_vl_architecture import (
@@ -84,12 +84,10 @@ class Qwen3VLMoeMLP(nn.Module):
         self.norm_topk_prob = True
 
         # Fused Qwen3VLMoeTextExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
-        intermediate_dim = experts.intermediate_dim
-        gate_up = experts.gate_up_proj.detach()
-        self.register_buffer("gate_proj_weight", gate_up[:, :intermediate_dim, :].contiguous())
-        self.register_buffer("up_proj_weight", gate_up[:, intermediate_dim:, :].contiguous())
-        experts.gate_up_proj = None
-        self.register_buffer("down_proj_weight", experts.down_proj.detach())
+        gate, up, down = split_fused_experts(experts)
+        self.register_buffer("gate_proj_weight", gate)
+        self.register_buffer("up_proj_weight", up)
+        self.register_buffer("down_proj_weight", down)
 
     def forward(self, x: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
@@ -61,7 +61,7 @@ class Qwen3VLMoeSparseMoeBlock(nn.Module):
         self.top_k = model.gate.top_k
         gate_weight = model.gate.weight
         gate = nn.Linear(gate_weight.shape[1], gate_weight.shape[0], bias=False)
-        gate.weight = nn.Parameter(gate_weight.detach().clone())
+        gate.weight = model.gate.weight
         self.gate = gate
         self.experts = Qwen3VLMoeMLP(model.experts, self.top_k)
 
@@ -89,10 +89,10 @@ class Qwen3VLMoeMLP(nn.Module):
 
         # Fused Qwen3VLMoeTextExperts: gate_up_proj [E, 2I, H], down_proj [E, H, I].
         intermediate_dim = experts.intermediate_dim
-        gate_up = experts.gate_up_proj.detach().clone()
+        gate_up = experts.gate_up_proj.detach()
         self.gate_proj.weight = nn.Parameter(gate_up[:, :intermediate_dim, :].contiguous())
         self.up_proj.weight = nn.Parameter(gate_up[:, intermediate_dim:, :].contiguous())
-        self.down_proj.weight = nn.Parameter(experts.down_proj.detach().clone().contiguous())
+        self.down_proj.weight = nn.Parameter(experts.down_proj.detach())
 
     def forward(self, x: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         masked_routing_weight = compute_masked_routing_weight_softmax_first(

--- a/src/optimum/rbln/transformers/utils/moe.py
+++ b/src/optimum/rbln/transformers/utils/moe.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import torch
-from torch import Tensor
+from torch import Tensor, nn
 
 
 def compute_masked_routing_weight_softmax_first(router_logits: Tensor, top_k: int, renormalize: bool) -> Tensor:
@@ -40,3 +40,15 @@ def compute_masked_routing_weight_topk_first(router_logits: Tensor, top_k: int) 
     masked = torch.zeros_like(router_logits_t, dtype=router_logits.dtype)
     masked.scatter_(0, topk_ids, topk_weights)
     return masked  # [E, T]
+
+
+def split_fused_experts(experts: nn.Module) -> tuple[Tensor, Tensor, Tensor]:
+    # HF packs gate|up along dim 1 of gate_up_proj [E, 2I, H]; custom_moe_glu takes them separately, so the
+    # halves are copied to be contiguous while down_proj [E, H, I] is shared. The fused tensor is released
+    # afterwards: the HF experts module is not run once wrapped, and keeping it would double host memory.
+    gate_up = experts.gate_up_proj.detach()
+    intermediate_dim = gate_up.shape[1] // 2
+    gate = gate_up[:, :intermediate_dim, :].contiguous()
+    up = gate_up[:, intermediate_dim:, :].contiguous()
+    experts.gate_up_proj = None
+    return gate, up, experts.down_proj.detach()


### PR DESCRIPTION
## Type of Change
- [x] Performance improvement
- [x] Code refactoring

## Changes Overview
HF 5.x stores MoE experts as fused `gate_up_proj [E, 2I, H]` and `down_proj [E, H, I]`, while
`custom_moe_glu` takes gate / up / down separately. The wrappers (qwen2_moe, qwen3_moe, qwen3_vl_moe,
mixtral, gemma4) split the fused tensor at construction, and did so with several redundant copies per
layer that stayed alive next to the HF model during compile. One commit per step:

1. **Drop redundant copies** (07548e06). `gate_up_proj.detach().clone()` before slicing (the slice's
   `.contiguous()` already copies), `down_proj.detach().clone().contiguous()` (already contiguous in the
   op's layout), the cloned router `gate.weight`, and full-size `nn.Linear(H, E*I)` weights that were
   randomly initialized only to be overwritten. Only the two gate/up halves are copied now; `down_proj`
   and the router weight share storage with the HF model.
2. **Release HF `gate_up_proj` after the split** (004a1327). The HF experts module is not executed after
   wrapping, so the split halves become the only copy and the per-model footprint stays flat.
3. **GPT-OSS** (68c63d23). The even/odd mxfp4 slices for gate/up blocks, scales and bias were
   non-contiguous views registered as buffers. The compiler copies them at ingest while the HF originals
   are alive, and `normalize_contiguous_` (#600) only walks parameters, so the same doubling happened at
   compile time. Copy once in the wrapper and release the HF `gate_up_proj` (`gate_up_proj_blocks` on
   older layouts). `down_proj` was already a contiguous view and stays shared.
4. **Register the split tensors as buffers** (0b332b10). The `nn.Linear(1, 1)` shells were never called;
   forward only read `.weight`. Register `gate_proj_weight` / `up_proj_weight` / `down_proj_weight`
   directly, as GPT-OSS does. rebel treats parameters and buffers alike
   (`named_parameters() + named_buffers()`). mixtral already had bare parameters and is unchanged here.

## Motivation and Context
Compiling Qwen3-30B-A3B in fp32 (~120 GB of weights) exceeds the 175 GB host budget because the
wrapper held a second copy of every expert weight while the HF model was still alive.

Measured on one real `Qwen3MoeSparseMoeBlock` (E=64, I=768, H=2048, fp32; HF expert weights = 1150 MB),
wrapping it with `Qwen3MoeSparseMoeBlock` from this repo and compiling that single block with
`rebel.compile_from_torch` (input `[1, 16, H]`):

| commit | wrap peak | steady after wrap | compile peak | HF `gate_up_proj` alive |
|---|---|---|---|---|
| dev (9eb38f94) | +267% | +100% | 4217 MB (3.67x) | yes |
| 1. drop copies | +66% | +66% | 3564 MB (3.09x) | yes |
| 2. release HF fused | +66% | ±0% | 2794 MB (2.42x) | no |
| 4. buffers (final) | +67% | ±0% | 2792 MB (2.44x) | no |

- *wrap peak*: maximum extra RSS at any moment during wrapper construction, relative to the HF expert weights.
- *steady*: extra RSS that remains after construction (HF model still alive). This is what accumulates
  across all layers of a model.
- *compile peak*: process peak RSS through `compile_from_torch` of the wrapped block, absolute and relative
  to the HF expert weights.

The remaining +66% transient is per layer (wrappers are built layer by layer), so it is negligible for a
full model. The remaining compile-time overhead (rebel-compiler's nn.Module clone / constant export) is
unchanged by this PR and is being looked at separately.

Passing strided views of `gate_up_proj` straight to the op was also tried: it compiles and gives
bit-identical output, but the compiler materializes contiguous copies anyway, so it saves nothing over
commit 1. A fused-weight variant of `custom_moe_glu` would only remove the per-layer transient and was not
pursued.

### Behavior change
After wrapping, the *source* HF model's `experts.gate_up_proj` (GPT-OSS: `gate_up_proj` /
`gate_up_proj_blocks`) is `None`, so its `forward` no longer works. `from_pretrained` builds the HF model
internally so this is invisible there. Callers of `from_model` that keep running the HF model afterwards
would be affected. Commits 2 and 3 carry this and can be dropped independently.

## Verification
- `tests/test_llm.py -k "TestQwen3MoeForCausalLM or TestQwen2MoeForCausalLM"` (OPTIMUM_RBLN_TEST_LEVEL=full) on RBLN-CA25: 16 passed on the final head.
- CPU eager check of the HF sparse-MoE block vs the wrapper for qwen3_moe, qwen2_moe, mixtral, qwen3_vl_moe:
  max |diff| ≤ 3.5e-10.
- GPT-OSS: no test or checkpoint cache in the repo; checked on a synthetic module with the same attributes
  (six gate/up buffers equal to the previous views and contiguous, `down_proj` shares HF storage, source released).
- gemma4 received the same mechanical change and was not run (no test in the repo).

## Related Issues
Slack thread on Qwen3-MoE host memory (weight copy vs. transformers 5.x fused layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
