### PR TITLE
model: resolve return_dict=None to config.use_return_dict in raw forwards

### DIFF
--- a/src/optimum/rbln/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/modeling_blip_2.py
@@ -126,6 +126,7 @@ class RBLNBlip2VisionModel(RBLNModel):
         Returns:
             BaseModelOutputWithPooling or tuple(torch.FloatTensor): The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a BaseModelOutputWithPooling object.
         """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         batch_size = pixel_values.shape[0]
         outputs = []
         for i in range(batch_size):
@@ -257,6 +258,7 @@ class RBLNBlip2QFormerModel(RBLNModel):
         Returns:
             BaseModelOutputWithPoolingAndCrossAttentions or tuple(torch.FloatTensor): The model outputs. If `return_dict=False` is passed, returns a tuple of tensors. Otherwise, returns a `BaseModelOutputWithPoolingAndCrossAttentions` object.
         """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         batch_size = query_embeds.shape[0]
         outputs = []
         for i in range(batch_size):

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -881,11 +881,12 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNDecoderOnlyModel, RBLNDecoderOnlyGener
         position_ids: torch.Tensor | None = None,
         token_type_ids: torch.Tensor | None = None,
         lora_int_ids: torch.Tensor | None = None,
-        return_dict: torch.Tensor | None = None,
+        return_dict: bool | None = None,
         output_hidden_states: bool | None = None,
         inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple[torch.FloatTensor]:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         if self.rbln_config.use_lora and lora_int_ids is None:
             if self.lora_int_ids is None:
                 raise ValueError(

--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -428,6 +428,7 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
         return_dict: bool | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         inputs_embeds = self._preprocess_prefill(
             input_ids,
             attention_mask,
@@ -579,6 +580,7 @@ class RBLNExaone4_5_ForConditionalGeneration(
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
 

--- a/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
@@ -161,6 +161,7 @@ class RBLNIdefics3VisionTransformer(RBLNModel):
         return_dict: bool | None = None,
         **kwargs,
     ) -> tuple | BaseModelOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         last_hidden_state_size = [
             pixel_values.shape[0],
             (self.config.image_size // self.config.patch_size) ** 2,
@@ -484,6 +485,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNImageIndexedBatchSortM
         inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | Idefics3CausalLMOutputWithPast:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -498,6 +498,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNImageIndexedBatchSortMixi
         inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | LlavaCausalLMOutputWithPast:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
@@ -478,6 +478,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNImageIndexedBatchSort
         inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -325,6 +325,7 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNImageIndexedBatchSort
         inputs_sorted: bool = False,
         **kwargs,
     ) -> tuple | RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(inputs_embeds if inputs_embeds is not None else input_ids, inputs_sorted)
         # Prefill
         if cache_position is None:

--- a/src/optimum/rbln/transformers/models/pixtral/modeling_pixtral.py
+++ b/src/optimum/rbln/transformers/models/pixtral/modeling_pixtral.py
@@ -48,6 +48,7 @@ class RBLNRuntimePixtralVisionModel(RBLNPytorchRuntime):
         **kwargs: Any,
     ) -> None:
         super().__init__(runtime, **kwargs)
+        self.config = config
         self.patch_positional_embedding = PixtralRotaryEmbedding(config)
         self.patch_size = config.patch_size
         self.image_size = config.image_size
@@ -62,6 +63,7 @@ class RBLNRuntimePixtralVisionModel(RBLNPytorchRuntime):
         return_dict: bool | None = None,
         **kwargs,
     ):
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         if pixel_values.shape[2] > self.max_image_size[0] or pixel_values.shape[3] > self.max_image_size[1]:
             raise ValueError("The height() and width of pixel_values can't be larger than max_image_size.")
 

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -549,6 +549,7 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
@@ -759,6 +760,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -436,6 +436,7 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
@@ -641,6 +642,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwenVLBatchSortMixin, RBLNQwen2VLM
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -675,6 +675,7 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         output_hidden_states: bool | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
@@ -862,6 +863,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwenVLBatchSortMixin, RBLNQwen3_5M
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         text_config = self.config.get_text_config()

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -624,6 +624,7 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
         inputs_embeds, position_embed, rope_deltas, visual_pos_mask, deepstack_visual_embeds = (
@@ -912,6 +913,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwenVLBatchSortMixin, RBLNQwen3VLM
         inputs_sorted: bool = False,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         self._require_sorted_batch_inputs(input_ids if input_ids is not None else inputs_embeds, inputs_sorted)
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)
         # Prefill


### PR DESCRIPTION
## Problem

Under HF semantics, `return_dict=None` means "follow `config.use_return_dict`" (default True). However, 19 RBLN forwards branched directly on `if not return_dict:`, so **a raw forward call that does not pass `return_dict` returned a plain tuple instead of a ModelOutput**.

- The `generate()` path was unaffected — it passes `return_dict=True` explicitly.
- Pipelines that call a model as a raw forward break. Real case: the Cosmos-Predict2.5 pipeline calls its text encoder (Qwen2.5-VL) as `text_encoder(input_ids, output_hidden_states=True)` → crashes with `'tuple' object has no attribute 'hidden_states'`. (Found during the #694 bring-up.)

This is a follow-up in the same family as #699 (raw-forward defaults for `attention_mask`/`generate_idx`).

## Changes

1. Add the standard HF boilerplate line to every affected forward:
   ```python
   return_dict = return_dict if return_dict is not None else self.config.use_return_dict
   ```
   Affected (12 files, 19 forwards): `decoderonly` (the CausalLM base — applies to every causal LLM), `qwen2_vl`×2, `qwen2_5_vl`×2, `qwen3_vl`×2, `qwen3_5`×2, `exaone4_5`×2, `llava`, `llava_next`, `idefics3`×2, `paligemma`, `blip_2`×2 (vision/qformer), `pixtral`
2. Fix the annotation typo in `RBLNDecoderOnlyModelForCausalLM.forward`: `return_dict: torch.Tensor | None` → `bool | None`
3. `RBLNRuntimePixtralVisionModel.__init__` received `config` but never stored it, so the fallback had no `self.config` to resolve against → added `self.config = config`

## How the targets were selected

An AST scan extracted every forward where the `return_dict` parameter defaults to `None`, the body branches on `if not return_dict:`, and no `use_return_dict` fallback exists. Re-scanning after the fix finds zero remaining instances.

Excluded as false positives:
- The `RBLNModel` base forward, `modeling_generic`, `colpali`, `colqwen2`, `detr`, `grounding_dino` — already have the fallback
- `clip`/`siglip`/`gemma4` — delegate to `RBLNModel.forward`, which has the fallback
- Everything on the diffusers side — `return_dict: bool = True` is diffusers' own convention

## Backward compatibility

The only behavior change: a raw forward called without `return_dict` now returns a ModelOutput instead of a tuple (= the standard HF behavior).

- Audited every internal caller that could depend on tuple returns: only sites passing an explicit `return_dict=False` exist (the t5 runtime wrapper, the siglip compile wrapper), and explicit `False` behaves exactly as before.
- colqwen2/colpali pass `return_dict=True` explicitly — unchanged. The `RBLNDecoderOnlyModel.forward` (L654) that paligemma calls takes no `return_dict` parameter at all — unchanged.

`ruff format` / `ruff check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)