### PR TITLE
model(qwen3_5): default gdn_chunk_size to 128 instead of inheriting prefill_chunk_size

### DIFF
--- a/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -18,8 +18,6 @@ from ....configuration_utils import RBLNModelConfig
 from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
 
 
-# The GatedDeltaNet prefill sub-chunk kernel supports at most this width, on every
-# NPU tier — so it is the gdn_chunk_size default, independent of prefill_chunk_size.
 MAX_GDN_CHUNK_SIZE = 128
 
 

--- a/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -18,6 +18,11 @@ from ....configuration_utils import RBLNModelConfig
 from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
 
 
+# The GatedDeltaNet prefill sub-chunk kernel supports at most this width, on every
+# NPU tier — so it is the gdn_chunk_size default, independent of prefill_chunk_size.
+MAX_GDN_CHUNK_SIZE = 128
+
+
 class RBLNQwen3_5ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     """
     Configuration class for RBLN Qwen3.5 (text backbone) causal language models.
@@ -52,13 +57,13 @@ class RBLNQwen3_5ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window
                 is split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
-                delta rule. Must divide `prefill_chunk_size`. Defaults to 128.
+                delta rule. Must divide `prefill_chunk_size`. Defaults to `MAX_GDN_CHUNK_SIZE` (128).
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             kwargs: Additional arguments passed to `RBLNDecoderOnlyModelForCausalLMConfig`.
         """
         super().__init__(**kwargs)
-        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
+        self.gdn_chunk_size = MAX_GDN_CHUNK_SIZE if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []
 
 
@@ -80,13 +85,13 @@ class RBLNQwen3_5TextModelConfig(RBLNDecoderOnlyModelConfig):
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window
                 is split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
-                delta rule. Must divide `prefill_chunk_size`. Defaults to 128.
+                delta rule. Must divide `prefill_chunk_size`. Defaults to `MAX_GDN_CHUNK_SIZE` (128).
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             kwargs: Additional arguments passed to `RBLNDecoderOnlyModelConfig`.
         """
         super().__init__(**kwargs)
-        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
+        self.gdn_chunk_size = MAX_GDN_CHUNK_SIZE if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []
 
 
@@ -149,7 +154,7 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window is
                 split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
-                delta rule. Must divide `prefill_chunk_size`. Defaults to 128.
+                delta rule. Must divide `prefill_chunk_size`. Defaults to `MAX_GDN_CHUNK_SIZE` (128).
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             visual (Optional[RBLNModelConfig]): Configuration for the vision encoder submodule.
@@ -169,7 +174,7 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
         # The vision encoder runs one image at a time, so force batch_size=1 on the submodule.
         self.visual = self.initialize_submodule_config(submodule_config=visual, force_kwargs=True, batch_size=1)
         self._load_visual_runtime = _load_visual_runtime
-        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
+        self.gdn_chunk_size = MAX_GDN_CHUNK_SIZE if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []
 
 
@@ -212,7 +217,7 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window is
                 split into `prefill_chunk_size // gdn_chunk_size` sub-chunks. Must divide
-                `prefill_chunk_size`. Defaults to 128. See rbln_chunk_gated_delta_rule.
+                `prefill_chunk_size`. Defaults to `MAX_GDN_CHUNK_SIZE` (128). See rbln_chunk_gated_delta_rule.
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             use_inputs_embeds (bool): Must be True — the vision encoder output is injected into inputs_embeds.
@@ -234,5 +239,5 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         # The vision encoder runs one image at a time, so force batch_size=1 on the submodule.
         self.visual = self.initialize_submodule_config(submodule_config=visual, force_kwargs=True, batch_size=1)
         self._load_visual_runtime = _load_visual_runtime
-        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
+        self.gdn_chunk_size = MAX_GDN_CHUNK_SIZE if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []

--- a/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -52,13 +52,13 @@ class RBLNQwen3_5ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window
                 is split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
-                delta rule. Must divide `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split).
+                delta rule. Must divide `prefill_chunk_size`. Defaults to 128.
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             kwargs: Additional arguments passed to `RBLNDecoderOnlyModelForCausalLMConfig`.
         """
         super().__init__(**kwargs)
-        self.gdn_chunk_size = gdn_chunk_size
+        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []
 
 
@@ -80,13 +80,13 @@ class RBLNQwen3_5TextModelConfig(RBLNDecoderOnlyModelConfig):
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window
                 is split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
-                delta rule. Must divide `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split).
+                delta rule. Must divide `prefill_chunk_size`. Defaults to 128.
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             kwargs: Additional arguments passed to `RBLNDecoderOnlyModelConfig`.
         """
         super().__init__(**kwargs)
-        self.gdn_chunk_size = gdn_chunk_size
+        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []
 
 
@@ -149,7 +149,7 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window is
                 split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
-                delta rule. Must divide `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split).
+                delta rule. Must divide `prefill_chunk_size`. Defaults to 128.
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             visual (Optional[RBLNModelConfig]): Configuration for the vision encoder submodule.
@@ -169,7 +169,7 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
         # The vision encoder runs one image at a time, so force batch_size=1 on the submodule.
         self.visual = self.initialize_submodule_config(submodule_config=visual, force_kwargs=True, batch_size=1)
         self._load_visual_runtime = _load_visual_runtime
-        self.gdn_chunk_size = gdn_chunk_size
+        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []
 
 
@@ -212,7 +212,7 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         Args:
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window is
                 split into `prefill_chunk_size // gdn_chunk_size` sub-chunks. Must divide
-                `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split). See rbln_chunk_gated_delta_rule.
+                `prefill_chunk_size`. Defaults to 128. See rbln_chunk_gated_delta_rule.
             linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
                 layer indices, populated automatically from `layer_types` at compile time (not user-set).
             use_inputs_embeds (bool): Must be True — the vision encoder output is injected into inputs_embeds.
@@ -234,5 +234,5 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         # The vision encoder runs one image at a time, so force batch_size=1 on the submodule.
         self.visual = self.initialize_submodule_config(submodule_config=visual, force_kwargs=True, batch_size=1)
         self._load_visual_runtime = _load_visual_runtime
-        self.gdn_chunk_size = gdn_chunk_size
+        self.gdn_chunk_size = 128 if gdn_chunk_size is None else gdn_chunk_size
         self.linear_attention_layers = linear_attention_layers or []

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -164,13 +164,17 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
         rbln_config = super()._update_rbln_config(
             preprocessors=preprocessors, model=model, model_config=model_config, rbln_config=rbln_config
         )
-        if rbln_config.gdn_chunk_size is None:
-            rbln_config.gdn_chunk_size = rbln_config.prefill_chunk_size
         if rbln_config.gdn_chunk_size > 128:
             raise ValueError(
                 f"gdn_chunk_size must be <= 128, got {rbln_config.gdn_chunk_size}. "
                 "Larger GatedDeltaNet sub-chunk sizes are not supported yet — "
                 "set gdn_chunk_size to a value <= 128 that divides prefill_chunk_size."
+            )
+        if rbln_config.prefill_chunk_size % rbln_config.gdn_chunk_size != 0:
+            raise ValueError(
+                f"gdn_chunk_size must divide prefill_chunk_size, got gdn_chunk_size="
+                f"{rbln_config.gdn_chunk_size} and prefill_chunk_size={rbln_config.prefill_chunk_size}. "
+                "Set gdn_chunk_size to a divisor of prefill_chunk_size that is <= 128."
             )
         return rbln_config
 
@@ -607,13 +611,17 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         rbln_config = super()._update_rbln_config(
             preprocessors=preprocessors, model=model, model_config=model_config, rbln_config=rbln_config
         )
-        if rbln_config.gdn_chunk_size is None:
-            rbln_config.gdn_chunk_size = rbln_config.prefill_chunk_size
         if rbln_config.gdn_chunk_size > 128:
             raise ValueError(
                 f"gdn_chunk_size must be <= 128, got {rbln_config.gdn_chunk_size}. "
                 "Larger GatedDeltaNet sub-chunk sizes are not supported yet — "
                 "set gdn_chunk_size to a value <= 128 that divides prefill_chunk_size."
+            )
+        if rbln_config.prefill_chunk_size % rbln_config.gdn_chunk_size != 0:
+            raise ValueError(
+                f"gdn_chunk_size must divide prefill_chunk_size, got gdn_chunk_size="
+                f"{rbln_config.gdn_chunk_size} and prefill_chunk_size={rbln_config.prefill_chunk_size}. "
+                "Set gdn_chunk_size to a divisor of prefill_chunk_size that is <= 128."
             )
         return rbln_config
 

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -41,6 +41,7 @@ from ...utils.multimodal_batch_sort import RBLNQwenVLBatchSortMixin
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
 from .configuration_qwen3_5 import (
+    MAX_GDN_CHUNK_SIZE,
     RBLNQwen3_5ForConditionalGenerationConfig,  # noqa: F401
     RBLNQwen3_5ModelConfig,  # noqa: F401
     RBLNQwen3_5VisionModelConfig,  # noqa: F401
@@ -166,17 +167,17 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
         rbln_config = super()._update_rbln_config(
             preprocessors=preprocessors, model=model, model_config=model_config, rbln_config=rbln_config
         )
-        if rbln_config.gdn_chunk_size > 128:
+        if rbln_config.gdn_chunk_size > MAX_GDN_CHUNK_SIZE:
             raise ValueError(
-                f"gdn_chunk_size must be <= 128, got {rbln_config.gdn_chunk_size}. "
+                f"gdn_chunk_size must be <= {MAX_GDN_CHUNK_SIZE}, got {rbln_config.gdn_chunk_size}. "
                 "Larger GatedDeltaNet sub-chunk sizes are not supported yet — "
-                "set gdn_chunk_size to a value <= 128 that divides prefill_chunk_size."
+                f"set gdn_chunk_size to a value <= {MAX_GDN_CHUNK_SIZE} that divides prefill_chunk_size."
             )
         if rbln_config.prefill_chunk_size % rbln_config.gdn_chunk_size != 0:
             raise ValueError(
                 f"gdn_chunk_size must divide prefill_chunk_size, got gdn_chunk_size="
                 f"{rbln_config.gdn_chunk_size} and prefill_chunk_size={rbln_config.prefill_chunk_size}. "
-                "Set gdn_chunk_size to a divisor of prefill_chunk_size that is <= 128."
+                f"Set gdn_chunk_size to a divisor of prefill_chunk_size that is <= {MAX_GDN_CHUNK_SIZE}."
             )
         return rbln_config
 
@@ -562,17 +563,17 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         rbln_config = super()._update_rbln_config(
             preprocessors=preprocessors, model=model, model_config=model_config, rbln_config=rbln_config
         )
-        if rbln_config.gdn_chunk_size > 128:
+        if rbln_config.gdn_chunk_size > MAX_GDN_CHUNK_SIZE:
             raise ValueError(
-                f"gdn_chunk_size must be <= 128, got {rbln_config.gdn_chunk_size}. "
+                f"gdn_chunk_size must be <= {MAX_GDN_CHUNK_SIZE}, got {rbln_config.gdn_chunk_size}. "
                 "Larger GatedDeltaNet sub-chunk sizes are not supported yet — "
-                "set gdn_chunk_size to a value <= 128 that divides prefill_chunk_size."
+                f"set gdn_chunk_size to a value <= {MAX_GDN_CHUNK_SIZE} that divides prefill_chunk_size."
             )
         if rbln_config.prefill_chunk_size % rbln_config.gdn_chunk_size != 0:
             raise ValueError(
                 f"gdn_chunk_size must divide prefill_chunk_size, got gdn_chunk_size="
                 f"{rbln_config.gdn_chunk_size} and prefill_chunk_size={rbln_config.prefill_chunk_size}. "
-                "Set gdn_chunk_size to a divisor of prefill_chunk_size that is <= 128."
+                f"Set gdn_chunk_size to a divisor of prefill_chunk_size that is <= {MAX_GDN_CHUNK_SIZE}."
             )
         return rbln_config
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -466,9 +466,6 @@ def test_qwen3_5_gdn_chunk_size_default_is_decoupled_from_prefill():
         (RBLNQwen3_5ForCausalLMConfig, {}),
         (RBLNQwen3_5ModelConfig, {"use_inputs_embeds": True}),
     ):
-        # The default is a fixed 128 (the GatedDeltaNet kernel cap), independent of
-        # prefill_chunk_size — deriving it from prefill made the default invalid on
-        # NPUs whose prefill default exceeds the cap.
         assert cls(**kwargs).gdn_chunk_size == MAX_GDN_CHUNK_SIZE
         assert cls(prefill_chunk_size=512, **kwargs).gdn_chunk_size == MAX_GDN_CHUNK_SIZE
         # An explicit value is preserved.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -412,3 +412,20 @@ def test_prefill_chunk_size_npu_wiring_e2e(tmp_path):
 
 if __name__ == "__main__":
     pytest.main()
+
+
+def test_qwen3_5_gdn_chunk_size_default_is_decoupled_from_prefill():
+    from optimum.rbln import RBLNQwen3_5ForCausalLMConfig, RBLNQwen3_5ModelConfig
+
+    # The multimodal config only constructs with use_inputs_embeds=True.
+    for cls, kwargs in (
+        (RBLNQwen3_5ForCausalLMConfig, {}),
+        (RBLNQwen3_5ModelConfig, {"use_inputs_embeds": True}),
+    ):
+        # The default is a fixed 128 (the GatedDeltaNet kernel cap), independent of
+        # prefill_chunk_size — deriving it from prefill made the default invalid on
+        # NPUs whose prefill default exceeds the cap.
+        assert cls(**kwargs).gdn_chunk_size == 128
+        assert cls(prefill_chunk_size=512, **kwargs).gdn_chunk_size == 128
+        # An explicit value is preserved.
+        assert cls(gdn_chunk_size=64, **kwargs).gdn_chunk_size == 64

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -459,6 +459,7 @@ if __name__ == "__main__":
 
 def test_qwen3_5_gdn_chunk_size_default_is_decoupled_from_prefill():
     from optimum.rbln import RBLNQwen3_5ForCausalLMConfig, RBLNQwen3_5ModelConfig
+    from optimum.rbln.transformers.models.qwen3_5.configuration_qwen3_5 import MAX_GDN_CHUNK_SIZE
 
     # The multimodal config only constructs with use_inputs_embeds=True.
     for cls, kwargs in (
@@ -468,7 +469,7 @@ def test_qwen3_5_gdn_chunk_size_default_is_decoupled_from_prefill():
         # The default is a fixed 128 (the GatedDeltaNet kernel cap), independent of
         # prefill_chunk_size — deriving it from prefill made the default invalid on
         # NPUs whose prefill default exceeds the cap.
-        assert cls(**kwargs).gdn_chunk_size == 128
-        assert cls(prefill_chunk_size=512, **kwargs).gdn_chunk_size == 128
+        assert cls(**kwargs).gdn_chunk_size == MAX_GDN_CHUNK_SIZE
+        assert cls(prefill_chunk_size=512, **kwargs).gdn_chunk_size == MAX_GDN_CHUNK_SIZE
         # An explicit value is preserved.
         assert cls(gdn_chunk_size=64, **kwargs).gdn_chunk_size == 64

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -461,7 +461,6 @@ def test_qwen3_5_gdn_chunk_size_default_is_decoupled_from_prefill():
     from optimum.rbln import RBLNQwen3_5ForCausalLMConfig, RBLNQwen3_5ModelConfig
     from optimum.rbln.transformers.models.qwen3_5.configuration_qwen3_5 import MAX_GDN_CHUNK_SIZE
 
-    # The multimodal config only constructs with use_inputs_embeds=True.
     for cls, kwargs in (
         (RBLNQwen3_5ForCausalLMConfig, {}),
         (RBLNQwen3_5ModelConfig, {"use_inputs_embeds": True}),


### PR DESCRIPTION
## Issue

`gdn_chunk_size` defaults to `prefill_chunk_size`, but prefill's default is device-tiered (`512 if "RBLN-CR" in npu else 128`). The GatedDeltaNet kernel cap is 128 on every tier, so on RBLN-CR the default config always fails before compiling:

```
ValueError: gdn_chunk_size must be <= 128, got 512.
```

All 7 REBEL qwen3.5/3.6/3.8 suites in rbln_deploy nightly #1443 die here; ATOM passes (prefill default 128). Closes #717.

## Fix

Default `gdn_chunk_size` to a fixed `MAX_GDN_CHUNK_SIZE` (128) in the config constructors — decoupled from `prefill_chunk_size`, so it is valid on every tier and recorded explicitly in `rbln_config.json`. The modeling sites keep the ≤128 cap check and now also enforce the divisibility the error message promised.

## Verify

- Contract test: default is 128 on both exported configs regardless of `prefill_chunk_size`; an explicit value is preserved.
- e2e on CR13 (Qwen3.5-0.8B, rebel-compiler 0.11.3.dev238), no `gdn_chunk_size` set: before → the `ValueError`; after → COMPILE_OK.

## Downstream

Once shipped, the workarounds become redundant: rbln_model_zoo#595 (`gdn_chunk_size: 128` in 7 REBEL scripts) and the executor cases' `-gcs 128` on CR13.
