### PR TITLE
model(decoderonly): tier the eager-attention max_seq_len limit for RBLN-CR13

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -33,9 +33,6 @@ def set_default_values(
     npu: str | None = None,
 ) -> tuple[str, int, int, int]:
     if attn_impl is None:
-        # RBLN-CR13+ eager attention indexes the sequence axis with int16, so its ceiling is
-        # 32767 — an unset attn_impl at >=32k would default into a config the target can never
-        # compile. Switch it to flash attention, like the kvcache_partition_len switch below.
         if max_seq_len is not None and max_seq_len >= DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH:
             npu = npu or rebel.get_npu_name(0)
             if npu_is_cr13_or_later(npu):
@@ -100,7 +97,6 @@ def validate_attention_method(
         if max_seq_len >= DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH and npu_is_cr13_or_later(
             npu or rebel.get_npu_name(0)
         ):
-            # int16 sequence indexing: 32768 passes the generic bound but cannot compile on CR13+.
             max_eager_seq_len = DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH - 1
         if max_seq_len > max_eager_seq_len:
             raise ValueError(

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import get_available_dram_per_chiplet, parse_byte_size
+from ..utils.runtime_utils import get_available_dram_per_chiplet, npu_is_cr13_or_later, parse_byte_size
 
 
 if TYPE_CHECKING:
@@ -33,7 +33,20 @@ def set_default_values(
     npu: str | None = None,
 ) -> tuple[str, int, int, int]:
     if attn_impl is None:
-        attn_impl = "eager"
+        # RBLN-CR13+ eager attention indexes the sequence axis with int16, so its ceiling is
+        # 32767 — an unset attn_impl at >=32k would default into a config the target can never
+        # compile. Switch it to flash attention, like the kvcache_partition_len switch below.
+        if max_seq_len is not None and max_seq_len >= DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH:
+            npu = npu or rebel.get_npu_name(0)
+            if npu_is_cr13_or_later(npu):
+                attn_impl = "flash_attn"
+                logger.warning(
+                    f"`attn_impl` was not explicitly set and `max_seq_len` ({max_seq_len}) exceeds the "
+                    f"eager-attention limit ({DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH - 1}) on {npu}. "
+                    "`attn_impl` has been automatically set to 'flash_attn'."
+                )
+        if attn_impl is None:
+            attn_impl = "eager"
 
     if prefill_chunk_size is None:
         # RBLN-CR NPUs use a larger prefill chunk for better prefill performance.
@@ -64,7 +77,13 @@ def set_default_values(
     return attn_impl, kvcache_partition_len, kvcache_block_size, prefill_chunk_size
 
 
-def validate_attention_method(attn_impl: str, kvcache_partition_len: int, kvcache_block_size: int, max_seq_len: int):
+def validate_attention_method(
+    attn_impl: str,
+    kvcache_partition_len: int,
+    kvcache_block_size: int,
+    max_seq_len: int,
+    npu: str | None = None,
+):
     if attn_impl not in ["eager", "flash_attn"]:
         raise ValueError(f"Unknown `attn_impl` : {attn_impl}. (Available : 'eager', 'flash_attn`)")
 
@@ -76,13 +95,20 @@ def validate_attention_method(attn_impl: str, kvcache_partition_len: int, kvcach
     # 1. `max_seq_len` should be multiple of `partition_len`.
     # 2. 1k <= `partition_len` <= 32k.
     # 3. `max_seq_len` should be at least 2048 (2 * minimum partition length).
-    if attn_impl == "eager" and max_seq_len > DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH:
-        raise ValueError(
-            f"`max_seq_len` is set to {max_seq_len}, "
-            f"which exceeds the limit of {DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH} for 'eager' attention. "
-            f"Please reduce the `max_seq_len` to {DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH} or lower,"
-            " or consider switching `attn_impl` to 'flash_attn' for larger sequence lengths."
-        )
+    if attn_impl == "eager":
+        max_eager_seq_len = DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH
+        if max_seq_len >= DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH and npu_is_cr13_or_later(
+            npu or rebel.get_npu_name(0)
+        ):
+            # int16 sequence indexing: 32768 passes the generic bound but cannot compile on CR13+.
+            max_eager_seq_len = DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH - 1
+        if max_seq_len > max_eager_seq_len:
+            raise ValueError(
+                f"`max_seq_len` is set to {max_seq_len}, "
+                f"which exceeds the limit of {max_eager_seq_len} for 'eager' attention on this target. "
+                f"Please reduce the `max_seq_len` to {max_eager_seq_len} or lower,"
+                " or consider switching `attn_impl` to 'flash_attn' for larger sequence lengths."
+            )
 
     if attn_impl == "flash_attn":
         if max_seq_len // kvcache_partition_len < 2 or max_seq_len % kvcache_partition_len != 0:

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -514,6 +514,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             kvcache_partition_len=rbln_config.kvcache_partition_len,
             kvcache_block_size=rbln_config.kvcache_block_size,
             max_seq_len=rbln_config.max_seq_len,
+            npu=rbln_config.npu,
         )
 
         # Validate kvcache_num_blocks against `num_min_blocks` / `num_full_blocks`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -403,6 +403,70 @@ class TestPrefillChunkSizeDefault:
             self._resolve(prefill_chunk_size=invalid_chunk_size, npu="RBLN-CA22")
 
 
+class TestCRTierEagerSeqLenLimit:
+    """RBLN-CR13+ eager attention tops out at max_seq_len 32767 (int16 sequence indexing):
+    an unset `attn_impl` at >=32768 defaults to flash_attn, an explicit 'eager' is rejected
+    up front instead of crashing the native compiler."""
+
+    @staticmethod
+    def _defaults(max_seq_len=32768, npu=None, **kwargs):
+        from optimum.rbln.transformers.modeling_attention_utils import set_default_values
+
+        return set_default_values(max_seq_len=max_seq_len, npu=npu, **kwargs)
+
+    @staticmethod
+    def _validate(attn_impl="eager", max_seq_len=32768, npu=None):
+        from optimum.rbln.transformers.modeling_attention_utils import validate_attention_method
+
+        block_size = 16384 if attn_impl == "flash_attn" else max_seq_len
+        partition_len = 16384 if attn_impl == "flash_attn" else None
+        validate_attention_method(
+            attn_impl=attn_impl,
+            kvcache_partition_len=partition_len,
+            kvcache_block_size=block_size,
+            max_seq_len=max_seq_len,
+            npu=npu,
+        )
+
+    def test_unset_attn_impl_upgrades_to_flash_on_cr13(self):
+        attn_impl, partition_len, block_size, _ = self._defaults(npu="RBLN-CR13")
+        assert attn_impl == "flash_attn"
+        assert partition_len == 16384
+        assert block_size == 16384
+
+    def test_unset_attn_impl_stays_eager_on_non_cr(self):
+        attn_impl, _, _, _ = self._defaults(npu="RBLN-CA22")
+        assert attn_impl == "eager"
+
+    def test_unset_attn_impl_stays_eager_below_the_limit(self):
+        attn_impl, _, _, _ = self._defaults(max_seq_len=16384, npu="RBLN-CR13")
+        assert attn_impl == "eager"
+
+    def test_unset_attn_impl_uses_attached_npu(self, monkeypatch):
+        monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
+        attn_impl, _, _, _ = self._defaults()
+        assert attn_impl == "flash_attn"
+
+    def test_explicit_flash_is_untouched(self):
+        attn_impl, partition_len, _, _ = self._defaults(attn_impl="flash_attn", npu="RBLN-CR13")
+        assert attn_impl == "flash_attn"
+        assert partition_len == 16384
+
+    def test_explicit_eager_32k_rejected_on_cr13(self):
+        with pytest.raises(ValueError, match="32767"):
+            self._validate(npu="RBLN-CR13")
+
+    def test_explicit_eager_32k_allowed_on_non_cr(self):
+        self._validate(npu="RBLN-CA22")
+
+    def test_explicit_eager_below_the_limit_allowed_on_cr13(self):
+        self._validate(max_seq_len=16384, npu="RBLN-CR13")
+
+    def test_eager_above_generic_limit_still_rejected_anywhere(self):
+        with pytest.raises(ValueError, match="exceeds the limit"):
+            self._validate(max_seq_len=65536, npu="RBLN-CA22")
+
+
 @pytest.mark.skip(reason="Compilation fails: cross-compiling for RBLN-CR03 on a CA25 runner, need to fix it")
 def test_prefill_chunk_size_npu_wiring_e2e(tmp_path):
     """Compile-time wiring: `rbln_config.npu` flows through `_update_attention_config` into the


### PR DESCRIPTION
## Issue

On RBLN-CR13+ the eager attention lowering indexes the sequence axis with int16, so its real ceiling is **32767**. The generic validation allows `max_seq_len <= 32768`, so the boundary config passes Python validation and crashes the native compiler (SIGABRT, no Python traceback). Since `attn_impl` defaults to eager, any default 32k export on CR13 hits this with no user mistake to point at — rbln_deploy nightly #1443: the exaone-3.5-2.4b / qwen2.5 / qwen3 32k REBEL suites all crashed exactly here. CA22 compiles the same config fine, so the eager ceiling is device-tiered.

Fixes #720.

## Resolution

- `set_default_values`: an unset `attn_impl` with `max_seq_len >= 32768` on CR13+ (`npu_is_cr13_or_later`) now defaults to `flash_attn` — the same auto-switch the function already performs when `kvcache_partition_len` is provided.
- `validate_attention_method`: an explicit `"eager"` in that region raises the existing descriptive `ValueError` with the per-target limit (32767) instead of deferring to the native crash. New optional `npu` parameter, wired from the single caller (`_update_attention_config`).
- Everything else unchanged: CA22 keeps eager-32768, sub-32k CR13 configs keep eager, explicit flash configs untouched.

## Verification

- Unit: `TestCRTierEagerSeqLenLimit` — 9 device-free cases (auto-upgrade on CR13, eager preserved on CA22/below-limit, attached-NPU fallback, explicit-eager rejection on CR13 only, generic >32768 rejection everywhere).
- E2E on forced RBLN-CR13 (rebel-compiler 0.11.3.dev238): 2-layer Qwen2.5-0.5B, `rbln_max_seq_len=32768`, no attention args → auto `flash_attn` + partition 16384, compile OK. The identical pre-fix config is deploy #1443's SIGABRT.
- The upgraded default equals the config verified on CR13 hardware in deploy manual run #1452 (rebellions-sw/rbln_model_zoo#594's bridge); this PR makes it the default.
