### PR TITLE
dependency: pin uv >=0.11.25 and bump CI uv to 0.11.33

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -12,7 +12,7 @@
 
 # syntax=docker/dockerfile:1.7
 
-ARG UV_VERSION=0.9.18
+ARG UV_VERSION=0.11.33
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 
 FROM python:3.12-slim-bookworm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,6 @@ packages = ["src/optimum"]
 allow-direct-references = true
 
 [tool.uv]
-# 0.11.25 changed lockfile serialization (redundant `environments` markers factored
-# out into `supported-markers`, astral-sh/uv#19933); older uv re-locking writes them
-# all back inline, producing a large noise diff. Gate every uv command on >= 0.11.25.
 required-version = ">=0.11.25"
 environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ packages = ["src/optimum"]
 allow-direct-references = true
 
 [tool.uv]
+# 0.11.25 changed lockfile serialization (redundant `environments` markers factored
+# out into `supported-markers`, astral-sh/uv#19933); older uv re-locking writes them
+# all back inline, producing a large noise diff. Gate every uv command on >= 0.11.25.
+required-version = ">=0.11.25"
 environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython'",
     "sys_platform == 'linux' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython'",


### PR DESCRIPTION
## What
- Add `required-version = ">=0.11.25"` to `[tool.uv]` in `pyproject.toml`.
- Bump CI uv image in `docker/ci/Dockerfile`: `UV_VERSION` 0.9.18 → 0.11.33.

## Why
uv 0.11.25 changed lockfile serialization (redundant `environments` markers factored into `supported-markers`, astral-sh/uv#19933). Re-locking with an older uv rewrites them back inline and produces a large noise diff. Gating every uv invocation on `>=0.11.25` keeps `uv.lock` diffs clean and consistent (mirrors the vllm-rbln setup).

Because `required-version` applies to **all** uv commands (incl. CI), the CI image must satisfy it — hence the Dockerfile bump to 0.11.33.

## Notes
- `uv.lock` unchanged: `uv@0.11.33 lock --check` passes on `dev` (already consistent).
- Verified the gate works: `uv@0.9.18` is rejected with `Required uv version >=0.11.25 does not match the running version 0.9.18`.
- Independent of the torchcodec 0.14 update (separate PR).

Made with [Cursor](https://cursor.com)