### PR TITLE
refactor(diffusers): move the SD ControlNet under models/controlnets

### DIFF
--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -387,7 +387,7 @@ class RBLNDiffusionMixin:
         prefix: str | None = "",
     ):
         # Compile multiple ControlNet models for a MultiControlNet setup
-        from .models.controlnet import RBLNControlNetModel
+        from .models.controlnets.controlnet import RBLNControlNetModel
         from .pipelines.controlnet import RBLNMultiControlNetModel
 
         compiled_controlnets = []

--- a/src/optimum/rbln/diffusers/models/__init__.py
+++ b/src/optimum/rbln/diffusers/models/__init__.py
@@ -28,7 +28,7 @@ _import_structure = {
         "RBLNUNet2DConditionModel",
         "RBLNUNetSpatioTemporalConditionModel",
     ],
-    "controlnet": ["RBLNControlNetModel"],
+    "controlnets": ["RBLNControlNetModel"],
     "transformers": [
         "RBLNPriorTransformer",
         "RBLNCosmosTransformer3DModel",
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
         RBLNAutoencoderKLTemporalDecoder,
         RBLNVQModel,
     )
-    from .controlnet import RBLNControlNetModel
+    from .controlnets import RBLNControlNetModel
     from .transformers import (
         RBLNCosmosTransformer3DModel,
         RBLNPriorTransformer,

--- a/src/optimum/rbln/diffusers/models/controlnets/__init__.py
+++ b/src/optimum/rbln/diffusers/models/controlnets/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .controlnet import RBLNControlNetModel

--- a/src/optimum/rbln/diffusers/models/controlnets/controlnet.py
+++ b/src/optimum/rbln/diffusers/models/controlnets/controlnet.py
@@ -19,12 +19,12 @@ from diffusers import ControlNetModel
 from diffusers.models.controlnets.controlnet import ControlNetOutput
 from transformers import PretrainedConfig
 
-from ...configuration_utils import RBLNCompileConfig, RBLNModelConfig
-from ...modeling import RBLNModel
-from ...utils.logging import get_logger
-from ...utils.model_utils import get_rbln_model_cls
-from ..configurations import RBLNControlNetModelConfig
-from ..modeling_diffusers import RBLNDiffusionMixin, RBLNDiffusionMixinConfig
+from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
+from ....modeling import RBLNModel
+from ....utils.logging import get_logger
+from ....utils.model_utils import get_rbln_model_cls
+from ...configurations import RBLNControlNetModelConfig
+from ...modeling_diffusers import RBLNDiffusionMixin, RBLNDiffusionMixinConfig
 
 
 if TYPE_CHECKING:

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/multicontrolnet.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/multicontrolnet.py
@@ -21,7 +21,7 @@ from diffusers.pipelines.controlnet.multicontrolnet import MultiControlNetModel
 
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
-from ...models.controlnet import RBLNControlNetModel
+from ...models.controlnets.controlnet import RBLNControlNetModel
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## What

Moves `src/optimum/rbln/diffusers/models/controlnet.py` to `models/controlnets/controlnet.py`, matching the upstream diffusers layout and our own `models/{autoencoders,transformers,unets}/` convention.

## Why now

Upstream diffusers restructured this in [#8768 "[Core] introduce controlnet module"](https://github.com/huggingface/diffusers/pull/8768) (merged 2024-11-07, **first released in v0.32.0**): every controlnet implementation lives under `models/controlnets/` (15 files today, including the new `controlnet_cosmos.py`). v0.32 kept a `models/controlnet.py` deprecation shim; current releases (0.38) have removed it. Our tree still had the flat `models/controlnet.py`, and the upcoming Cosmos-Transfer2.5 work (#725) adds `models/controlnets/controlnet_cosmos.py` — this PR brings the existing SD ControlNet in line so the folder isn't half-and-half.

## Changes

- `git mv models/controlnet.py models/controlnets/controlnet.py` (+ package `__init__`)
- Import-path updates: relative-import depth inside the moved file, `models/__init__.py` lazy structure (`"controlnet"` → `"controlnets"`), `pipelines/controlnet/multicontrolnet.py`, `modeling_diffusers.py`
- No public API change: `optimum.rbln.RBLNControlNetModel` re-exports are untouched. The internal module path `optimum.rbln.diffusers.models.controlnet` goes away (no shim), same as upstream's end state.

## Verification

- `TestSDControlNetModel` 8 passed, `TestSDMultiControlNetModel` 8 passed (NPU)
- ruff format/check pass

Note: #725 adds `models/controlnets/controlnet_cosmos.py` on its branch; whichever lands second has a one-line `__init__` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)