### PR TITLE
other: ci - run PR pytest suites on Obedients alongside GHA

### DIFF
--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -17,9 +17,12 @@ _secrets: &secrets
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
 
+# --reinstall-package: the editable wheel may already sit in the shared uv cache,
+# built by another pod. Rebuilding here runs the hatch-vcs hook that writes the
+# gitignored src/optimum/rbln/__version__.py into this checkout.
 _sync: &sync |
   echo '--- :package: uv sync'
-  uv sync --locked --python 3.12 --group tests
+  uv sync --locked --python 3.12 --group tests --reinstall-package optimum-rbln
   bash .buildkite/scripts/install-rebel-compiler.sh
 
 _cpu: &cpu

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -23,6 +23,13 @@ _secrets: &secrets
 _sync: &sync |
   echo '--- :package: uv sync'
   uv sync --locked --python 3.12 --group tests --reinstall-package optimum-rbln
+  uv --version
+  if [ ! -f src/optimum/rbln/__version__.py ]; then
+    echo "hatch-vcs did not write src/optimum/rbln/__version__.py into this checkout"
+    find /workspace /root /tmp -name __version__.py -path '*optimum/rbln*' 2>/dev/null | head
+    uv run --no-sync python -c "import importlib.metadata as m, pathlib; pathlib.Path('src/optimum/rbln/__version__.py').write_text('__version__ = version = %r\n' % m.version('optimum-rbln'))"
+    cat src/optimum/rbln/__version__.py
+  fi
   bash .buildkite/scripts/install-rebel-compiler.sh
 
 _cpu: &cpu

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -17,28 +17,17 @@ _secrets: &secrets
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
 
-# --reinstall-package: the editable wheel may already sit in the shared uv cache,
-# built by another pod. Rebuilding here runs the hatch-vcs hook that writes the
-# gitignored src/optimum/rbln/__version__.py into this checkout.
+# Pods share UV_CACHE_DIR, so steps building the same commit at the same time can
+# end up reusing one pod's editable build. Only that pod then has the gitignored
+# src/optimum/rbln/__version__.py the hatch-vcs hook writes; the other pods write
+# it here from the installed metadata (the code only reads __version__).
 _sync: &sync |
   echo '--- :package: uv sync'
   uv sync --locked --python 3.12 --group tests --reinstall-package optimum-rbln
-  uv --version
   if [ ! -f src/optimum/rbln/__version__.py ]; then
-    echo "hatch-vcs did not write src/optimum/rbln/__version__.py into this checkout"
-    find /workspace /root /tmp -name __version__.py -path '*optimum/rbln*' 2>/dev/null | head
     uv run --no-sync python -c "import importlib.metadata as m, pathlib; pathlib.Path('src/optimum/rbln/__version__.py').write_text('__version__ = version = %r\n' % m.version('optimum-rbln'))"
-    cat src/optimum/rbln/__version__.py
   fi
   bash .buildkite/scripts/install-rebel-compiler.sh
-
-_cpu: &cpu
-  cpu:
-    requests: "4"
-    limits: "4"
-  memory:
-    requests: "32Gi"
-    limits: "32Gi"
 
 _npu: &npu
   npu:
@@ -48,7 +37,7 @@ _npu: &npu
 steps:
   - label: ":pytest: config"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
-    resources: *cpu
+    resources: *npu
     secrets: *secrets
     timeout_in_minutes: 60
     command:
@@ -57,7 +46,7 @@ steps:
 
   - label: ":pytest: cli-basic"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
-    resources: *cpu
+    resources: *npu
     secrets: *secrets
     timeout_in_minutes: 60
     command:

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -1,0 +1,109 @@
+# optimum-rbln PR pytest suites, uploaded by .buildkite/pr.yml.
+# Mirrors the GHA matrix in .github/workflows/rbln_optimum_pytest.yaml (test_level=default).
+
+notify:
+  - github_commit_status:
+      context: "[OB] Optimum-RBLN pytest"
+
+env:
+  UV_CACHE_DIR: "/mnt/uv_cache"
+  UV_LINK_MODE: "symlink"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+  OPTIMUM_RBLN_TEST_LEVEL: "default"
+
+_secrets: &secrets
+  UV_INDEX_REBELLIONS_USERNAME: REBEL_SW_DEV_USERNAME
+  UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
+  HF_TOKEN: HF_TOKEN
+  HF_HOME: HF_HOME
+
+_sync: &sync |
+  echo '--- :package: uv sync'
+  uv sync --locked --python 3.12 --group tests
+  bash .buildkite/scripts/install-rebel-compiler.sh
+
+_cpu: &cpu
+  cpu:
+    requests: "4"
+    limits: "4"
+  memory:
+    requests: "32Gi"
+    limits: "32Gi"
+
+_npu: &npu
+  npu:
+    count: 1
+    product: "RBLN-CA25"
+
+steps:
+  - label: ":pytest: config"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *cpu
+    secrets: *secrets
+    timeout_in_minutes: 60
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh config"
+
+  - label: ":pytest: cli-basic"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *cpu
+    secrets: *secrets
+    timeout_in_minutes: 60
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh cli-basic"
+
+  - label: ":pytest: transformers"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *npu
+    secrets: *secrets
+    timeout_in_minutes: 120
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh transformers"
+
+  - label: ":pytest: diffusers"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *npu
+    secrets: *secrets
+    timeout_in_minutes: 120
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh diffusers"
+
+  - label: ":pytest: llm 1/4"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *npu
+    secrets: *secrets
+    timeout_in_minutes: 120
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh llm 1"
+
+  - label: ":pytest: llm 2/4"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *npu
+    secrets: *secrets
+    timeout_in_minutes: 120
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh llm 2"
+
+  - label: ":pytest: llm 3/4"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *npu
+    secrets: *secrets
+    timeout_in_minutes: 120
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh llm 3"
+
+  - label: ":pytest: llm 4/4"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    resources: *npu
+    secrets: *secrets
+    timeout_in_minutes: 120
+    command:
+      - *sync
+      - "bash .buildkite/scripts/run-suite.sh llm 4"

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -1,0 +1,21 @@
+# Entry pipeline for PR builds. Gates run first; the pytest pipeline is uploaded
+# only after they pass, with --git-diff-base so if_changed can be used later.
+steps:
+  - label: ":closed_lock_with_key: team-member gate"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    secrets:
+      - GIT_PAT
+    command:
+      - "bash .buildkite/scripts/gate-team-member.sh"
+
+  - wait: ~
+
+  - label: ":sparkles: upload pytest"
+    checkout:
+      sparse:
+        paths:
+          - .buildkite
+    command: |
+      TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}
+      git fetch origin $$TARGET_BRANCH
+      buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml --git-diff-base origin/$$TARGET_BRANCH

--- a/.buildkite/scripts/gate-team-member.sh
+++ b/.buildkite/scripts/gate-team-member.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Team-member policy gate (moved off the GHA check-team-member job). Same as vllm-rbln.
+
+set -euo pipefail
+
+if [ "${BUILDKITE_PULL_REQUEST:-false}" = "false" ]; then
+  echo "Not a pull-request build; skipping team-member gate."
+  exit 0
+fi
+
+command -v jq >/dev/null 2>&1 || { apt-get update && apt-get install -y jq curl; }
+
+if [ -z "${GIT_PAT:-}" ]; then
+  echo "GIT_PAT is not set; cannot verify PR author." >&2
+  exit 1
+fi
+
+repo=$(printf '%s' "${BUILDKITE_REPO}" | sed -E 's#^.*github\.com[:/]##; s#\.git$##')
+
+api="https://api.github.com"
+auth="Authorization: Bearer ${GIT_PAT}"
+
+author=$(curl -fsS -H "${auth}" \
+  "${api}/repos/${repo}/pulls/${BUILDKITE_PULL_REQUEST}" | jq -r '.user.login')
+if [ -z "${author}" ] || [ "${author}" = "null" ]; then
+  echo "Could not resolve author of PR #${BUILDKITE_PULL_REQUEST} in ${repo}." >&2
+  exit 1
+fi
+echo "PR #${BUILDKITE_PULL_REQUEST} author: ${author}"
+
+query='{"query":"query { organization(login: \"rbln-sw\") { team1: team(slug: \"sw\") { members(first: 100) { nodes { login } } } team2: team(slug: \"fsw\") { members(first: 100) { nodes { login } } } } }"}'
+members=$(curl -fsS -H "${auth}" -H "Content-Type: application/json" -d "${query}" "${api}/graphql" \
+  | jq -r '.data.organization.team1.members.nodes[].login, .data.organization.team2.members.nodes[].login' \
+  | sort -u)
+
+if printf '%s\n' "${members}" | grep -qx "${author}"; then
+  echo "✅ ${author} is on the sw/fsw team -- allowed."
+  exit 0
+fi
+
+code=$(curl -sS -o /dev/null -w '%{http_code}' -H "${auth}" \
+  "${api}/repos/${repo}/collaborators/${author}" || echo "000")
+if [ "${code}" = "204" ]; then
+  echo "✅ ${author} is a repo collaborator -- allowed."
+  exit 0
+fi
+
+echo "❌ ${author} is neither an sw/fsw team member nor a collaborator -- blocking CI." >&2
+exit 1

--- a/.buildkite/scripts/install-rebel-compiler.sh
+++ b/.buildkite/scripts/install-rebel-compiler.sh
@@ -3,14 +3,14 @@
 # Same file the GHA workflows read, so the two CIs test the same compiler.
 set -euo pipefail
 
-: "${REBEL_PYPI_ENDPOINT:?not set}"
+: "${REBEL_PYPI_INTERNAL_ENDPOINT:?not set}"
 : "${UV_INDEX_REBELLIONS_USERNAME:?not set}"
 : "${UV_INDEX_REBELLIONS_PASSWORD:?not set}"
 
 version=$(grep '^rebel_compiler_version:' .github/version.yaml | cut -d ':' -f2 | tr -d ' ')
 [ -n "$version" ] || { echo "rebel_compiler_version not found in .github/version.yaml" >&2; exit 1; }
 
-host="${REBEL_PYPI_ENDPOINT%/}"
+host="${REBEL_PYPI_INTERNAL_ENDPOINT%/}"
 index="https://${UV_INDEX_REBELLIONS_USERNAME}:${UV_INDEX_REBELLIONS_PASSWORD}@${host#https://}/simple"
 
 echo "--- :package: rebel-compiler==${version}"

--- a/.buildkite/scripts/install-rebel-compiler.sh
+++ b/.buildkite/scripts/install-rebel-compiler.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Install the rebel-compiler pinned in .github/version.yaml into the synced venv.
+# Same file the GHA workflows read, so the two CIs test the same compiler.
+set -euo pipefail
+
+: "${REBEL_PYPI_ENDPOINT:?not set}"
+: "${UV_INDEX_REBELLIONS_USERNAME:?not set}"
+: "${UV_INDEX_REBELLIONS_PASSWORD:?not set}"
+
+version=$(grep '^rebel_compiler_version:' .github/version.yaml | cut -d ':' -f2 | tr -d ' ')
+[ -n "$version" ] || { echo "rebel_compiler_version not found in .github/version.yaml" >&2; exit 1; }
+
+host="${REBEL_PYPI_ENDPOINT%/}"
+index="https://${UV_INDEX_REBELLIONS_USERNAME}:${UV_INDEX_REBELLIONS_PASSWORD}@${host#https://}/simple"
+
+echo "--- :package: rebel-compiler==${version}"
+uv pip install --extra-index-url "$index" "rebel-compiler==${version}"

--- a/.buildkite/scripts/run-suite.sh
+++ b/.buildkite/scripts/run-suite.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# run-suite.sh <suite> [group]
+# Runs one suite of the GHA matrix, honoring the same [skip-*] commit-message
+# directives. BUILDKITE_MESSAGE is the PR head commit message, as in GHA.
+set -euo pipefail
+
+suite="${1:?usage: run-suite.sh <suite> [group]}"
+group="${2:-}"
+
+case "$suite" in
+  transformers) tag="[skip-transformers]" ;;
+  diffusers)    tag="[skip-diffusers]" ;;
+  llm)          tag="[skip-llms]" ;;
+  cli-*)        tag="[skip-cli]" ;;
+  *)            tag="" ;;
+esac
+if [ -n "$tag" ] && [[ "${BUILDKITE_MESSAGE:-}" == *"$tag"* ]]; then
+  echo "Found $tag in commit message, skipping $suite"
+  exit 0
+fi
+
+echo "--- :pytest: ${suite}${group:+ (group ${group}/4)}"
+case "$suite" in
+  config)
+    uv run --no-sync pytest -n 1 tests/test_config.py -vv --durations 0 ;;
+  transformers)
+    uv run --no-sync pytest -n 1 tests/test_transformers.py -vv --durations 0 ;;
+  diffusers)
+    uv run --no-sync pytest -n 1 tests/test_diffusers.py -vv --durations 0 ;;
+  llm)
+    [ -n "$group" ] || { echo "llm needs a group (1-4)" >&2; exit 2; }
+    uv run --no-sync pytest -n 1 tests/test_llm.py --splits 4 --group "$group" -vv --durations 0 ;;
+  cli-basic)
+    uv run --no-sync .github/scripts/test_cli.py basic ;;
+  *)
+    echo "unknown suite: $suite" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary
Phase 1 of moving optimum-rbln CI off GitHub Actions onto Obedients, following the vllm-rbln layout (#882 / #931 there).

- `.buildkite/pr.yml`: team-member gate, then uploads the pytest pipeline with `--git-diff-base` (ready for `if_changed` in a later phase).
- `.buildkite/pipelines/pytest/pipeline.yml`: one step per GHA matrix entry — `config`, `cli-basic`, `transformers`, `diffusers`, `llm` 1–4, each on 1× RBLN-CA25 (`config`/`cli-basic` compile without an explicit `npu`, so they need an NPU pod too). Reports `[OB] Optimum-RBLN pytest` as a commit status.
- `scripts/install-rebel-compiler.sh` installs the version pinned in `.github/version.yaml` from the cluster's internal PyPI (`REBEL_PYPI_INTERNAL_ENDPOINT`), so both CIs test the same compiler.
- The sync step writes `src/optimum/rbln/__version__.py` from the installed metadata when the hatch-vcs hook left none: pods share `UV_CACHE_DIR`, so concurrent steps building the same commit reuse one pod's editable build and only that pod gets the generated file (seen in builds #2–#4).
- `scripts/run-suite.sh` runs one suite and honors the same `[skip-transformers]` / `[skip-diffusers]` / `[skip-llms]` / `[skip-cli]` directives via `BUILDKITE_MESSAGE`.

GHA pytest is untouched in this PR; it stays on until Obedients results match on the same commits. Deploy, compiler-update bot, renovate and PR-title check stay on GHA.

Working doc (phases, mapping, open items): internal artifact, ask thkim.

## Test plan
- [x] Obedients build passes gate → sync → rebel-compiler install → all 8 suites ([build #5](https://obedients.k8s.rebellions.in/orgs/main/pipelines/optimum-rbln-pr-ci/builds/5), 18 min incl. queue)
- [x] `config` / `cli-basic` on CPU pods: not possible (compile needs an NPU) → moved to NPU
- [ ] Suite results match GHA on the same commit (3+ PRs) — 1/3: all 10 GHA suites and all 8 OB suites pass on this branch
- [ ] `[skip-llms]` commit skips the llm steps
- [ ] Webhook builds: PR open / push did not create OB builds yet; builds #1–#5 were triggered manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)
