### PR TITLE
model(decoderonly): per-family attention limits (ATOM 32k / REBEL 16k)

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
-DEFAULT_FLASH_ATTN_PARTITION_LENGTH = 16_384
 MAX_SLIDING_WINDOW_SIZE = 32_768
 
 
@@ -34,6 +33,7 @@ class AttentionLimits:
     max_eager_seq_len: int
     min_flash_partition_len: int
     max_flash_partition_len: int
+    default_flash_partition_len: int
 
     @property
     def min_flash_max_seq_len(self) -> int:
@@ -46,6 +46,7 @@ ATOM_ATTENTION_LIMITS = AttentionLimits(
     max_eager_seq_len=32_768,
     min_flash_partition_len=1_024,
     max_flash_partition_len=32_768,
+    default_flash_partition_len=16_384,
 )
 
 REBEL_ATTENTION_LIMITS = AttentionLimits(
@@ -53,6 +54,7 @@ REBEL_ATTENTION_LIMITS = AttentionLimits(
     max_eager_seq_len=16_384,
     min_flash_partition_len=1_024,
     max_flash_partition_len=16_384,
+    default_flash_partition_len=8_192,
 )
 
 
@@ -98,7 +100,7 @@ def set_default_values(
             )
 
     if kvcache_partition_len is None and attn_impl == "flash_attn":
-        kvcache_partition_len = DEFAULT_FLASH_ATTN_PARTITION_LENGTH
+        kvcache_partition_len = get_attention_limits(npu).default_flash_partition_len
 
     if kvcache_block_size is None:
         if attn_impl == "eager":

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -54,7 +54,7 @@ REBEL_ATTENTION_LIMITS = AttentionLimits(
     min_flash_partition_len=1_024,
     max_flash_partition_len=16_384,
     default_flash_partition_len=8_192,
-    max_sliding_window=16_384,
+    max_sliding_window=32_767,
 )
 
 

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import rebel
@@ -17,11 +18,55 @@ logger = get_logger()
 
 
 DEFAULT_FLASH_ATTN_PARTITION_LENGTH = 16_384
-DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH = 32_768
-MIN_FLASH_ATTN_MAX_SEQ_LEN = 2048
-MIN_FLASH_ATTN_PARTITION_LENGTH = 1024
-MAX_FLASH_ATTN_PARTITION_LENGTH = 32_768
 MAX_SLIDING_WINDOW_SIZE = 32_768
+
+
+@dataclass(frozen=True)
+class AttentionLimits:
+    """Bounds on the extent of the KV cache's dynamic axis for one NPU family.
+
+    `set_default_values` derives that extent from `max_seq_len` for eager attention and from
+    `kvcache_partition_len` for flash attention, so the device limit bounds a different
+    parameter in each mode.
+    """
+
+    name: str
+    max_eager_seq_len: int
+    min_flash_partition_len: int
+    max_flash_partition_len: int
+
+    @property
+    def min_flash_max_seq_len(self) -> int:
+        # Flash attention needs at least two partitions.
+        return 2 * self.min_flash_partition_len
+
+
+ATOM_ATTENTION_LIMITS = AttentionLimits(
+    name="ATOM",
+    max_eager_seq_len=32_768,
+    min_flash_partition_len=1_024,
+    max_flash_partition_len=32_768,
+)
+
+REBEL_ATTENTION_LIMITS = AttentionLimits(
+    name="REBEL",
+    max_eager_seq_len=16_384,
+    min_flash_partition_len=1_024,
+    max_flash_partition_len=16_384,
+)
+
+
+def get_attention_limits(npu: str | None = None) -> AttentionLimits:
+    """Attention limits of the target NPU, falling back to the attached device.
+
+    ATOM accepts twice the dynamic-axis extent REBEL does, so the two families carry separate
+    limits. When the family cannot be resolved — compiling on a host without an NPU and without
+    `npu` pinned on the config — the wider ATOM limits apply and the compiler stays the backstop.
+    """
+    npu = npu or (rebel.get_npu_name(0) if rebel.npu_is_available(0) else None)
+    if npu is not None and npu.startswith("RBLN-CR"):
+        return REBEL_ATTENTION_LIMITS
+    return ATOM_ATTENTION_LIMITS
 
 
 def set_default_values(
@@ -64,23 +109,34 @@ def set_default_values(
     return attn_impl, kvcache_partition_len, kvcache_block_size, prefill_chunk_size
 
 
-def validate_attention_method(attn_impl: str, kvcache_partition_len: int, kvcache_block_size: int, max_seq_len: int):
+def validate_attention_method(
+    attn_impl: str,
+    kvcache_partition_len: int,
+    kvcache_block_size: int,
+    max_seq_len: int,
+    npu: str | None = None,
+):
     if attn_impl not in ["eager", "flash_attn"]:
         raise ValueError(f"Unknown `attn_impl` : {attn_impl}. (Available : 'eager', 'flash_attn`)")
 
+    limits = get_attention_limits(npu)
+
     ## Checking Constraints...
+    # The device bounds the extent of the KV cache's dynamic axis, which eager attention sets to
+    # `max_seq_len` and flash attention to `kvcache_partition_len`. ATOM allows 32k, REBEL 16k.
+
     # Constraint of eager attention:
-    # - `max_seq_len` <= 32k
+    # - `max_seq_len` <= `limits.max_eager_seq_len`
 
     # Constraints of flash attention:
     # 1. `max_seq_len` should be multiple of `partition_len`.
-    # 2. 1k <= `partition_len` <= 32k.
-    # 3. `max_seq_len` should be at least 2048 (2 * minimum partition length).
-    if attn_impl == "eager" and max_seq_len > DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH:
+    # 2. `limits.min_flash_partition_len` <= `partition_len` <= `limits.max_flash_partition_len`.
+    # 3. `max_seq_len` should be at least twice the minimum partition length.
+    if attn_impl == "eager" and max_seq_len > limits.max_eager_seq_len:
         raise ValueError(
             f"`max_seq_len` is set to {max_seq_len}, "
-            f"which exceeds the limit of {DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH} for 'eager' attention. "
-            f"Please reduce the `max_seq_len` to {DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH} or lower,"
+            f"which exceeds the {limits.name} limit of {limits.max_eager_seq_len} for 'eager' attention. "
+            f"Please reduce the `max_seq_len` to {limits.max_eager_seq_len} or lower,"
             " or consider switching `attn_impl` to 'flash_attn' for larger sequence lengths."
         )
 
@@ -90,16 +146,16 @@ def validate_attention_method(attn_impl: str, kvcache_partition_len: int, kvcach
                 f"`max_seq_len` ({max_seq_len}) must be a multiple of `kvcache_partition_len` ({kvcache_partition_len}) "
                 f"when using 'flash_attn'. Please adjust either value to meet this requirement."
             )
-        elif not (MIN_FLASH_ATTN_PARTITION_LENGTH <= kvcache_partition_len <= MAX_FLASH_ATTN_PARTITION_LENGTH):
+        elif not (limits.min_flash_partition_len <= kvcache_partition_len <= limits.max_flash_partition_len):
             raise ValueError(
-                f"`kvcache_partition_len` ({kvcache_partition_len}) is out of the supported range for 'flash_attn' "
-                f"({MIN_FLASH_ATTN_PARTITION_LENGTH} <= `kvcache_partition_len` <= {MAX_FLASH_ATTN_PARTITION_LENGTH}). "
-                f"Please provide a valid value within this range."
+                f"`kvcache_partition_len` ({kvcache_partition_len}) is out of the {limits.name} supported range "
+                f"for 'flash_attn' ({limits.min_flash_partition_len} <= `kvcache_partition_len` <= "
+                f"{limits.max_flash_partition_len}). Please provide a valid value within this range."
             )
-        elif max_seq_len < MIN_FLASH_ATTN_MAX_SEQ_LEN:
+        elif max_seq_len < limits.min_flash_max_seq_len:
             raise ValueError(
                 f"`max_seq_len` ({max_seq_len}) is too small for 'flash_attn'. The minimum "
-                f"supported value is {MIN_FLASH_ATTN_MAX_SEQ_LEN}. Please increase `max_seq_len` to meet "
+                f"supported value is {limits.min_flash_max_seq_len}. Please increase `max_seq_len` to meet "
                 "this requirement, or consider switching `attn_impl` to 'eager' for shorter lengths."
             )
 

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -87,8 +87,6 @@ def set_default_values(
     if attn_impl is None:
         attn_impl = "eager"
 
-    # Resolve once: the prefill-chunk default and the attention limits below both read it, and
-    # resolving at each use made the result depend on which arguments the caller happened to pass.
     npu = resolve_npu_or_none(npu)
 
     if prefill_chunk_size is None:
@@ -130,8 +128,6 @@ def validate_attention_method(
 
     limits = get_attention_limits(npu)
 
-    # The device bounds the extent of the KV cache's dynamic axis, which eager attention sets to
-    # `max_seq_len` and flash attention to `kvcache_partition_len`. ATOM allows 32k, REBEL 16k.
     if attn_impl == "eager" and max_seq_len > limits.max_eager_seq_len:
         raise ValueError(
             f"`max_seq_len` is set to {max_seq_len}, "
@@ -173,8 +169,6 @@ def validate_attention_method(
 
 
 def validate_sliding_window(rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig") -> None:
-    # A sliding-window cache makes `sliding_window` the dynamic axis, so the same per-family limit
-    # bounds it, less the prefill chunk in flight.
     limits = get_attention_limits(rbln_config.npu)
     max_sliding_window = limits.max_sliding_window - rbln_config.prefill_chunk_size
     if rbln_config.sliding_window > max_sliding_window:

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import get_available_dram_per_chiplet, parse_byte_size
+from ..utils.runtime_utils import get_available_dram_per_chiplet, parse_byte_size, resolve_npu_or_none
 
 
 if TYPE_CHECKING:
@@ -17,16 +17,13 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
-MAX_SLIDING_WINDOW_SIZE = 32_768
-
-
 @dataclass(frozen=True)
 class AttentionLimits:
     """Bounds on the extent of the KV cache's dynamic axis for one NPU family.
 
-    `set_default_values` derives that extent from `max_seq_len` for eager attention and from
-    `kvcache_partition_len` for flash attention, so the device limit bounds a different
-    parameter in each mode.
+    The bounded parameter differs per attention mode, because that is what each mode makes the
+    cache's dynamic axis: `max_seq_len` for eager, `kvcache_partition_len` for flash attention,
+    and `sliding_window` for a sliding-window cache.
     """
 
     name: str
@@ -34,6 +31,7 @@ class AttentionLimits:
     min_flash_partition_len: int
     max_flash_partition_len: int
     default_flash_partition_len: int
+    max_sliding_window: int
 
     @property
     def min_flash_max_seq_len(self) -> int:
@@ -47,6 +45,7 @@ ATOM_ATTENTION_LIMITS = AttentionLimits(
     min_flash_partition_len=1_024,
     max_flash_partition_len=32_768,
     default_flash_partition_len=16_384,
+    max_sliding_window=32_768,
 )
 
 REBEL_ATTENTION_LIMITS = AttentionLimits(
@@ -55,20 +54,26 @@ REBEL_ATTENTION_LIMITS = AttentionLimits(
     min_flash_partition_len=1_024,
     max_flash_partition_len=16_384,
     default_flash_partition_len=8_192,
+    max_sliding_window=16_384,
 )
 
 
 def get_attention_limits(npu: str | None = None) -> AttentionLimits:
-    """Attention limits of the target NPU, falling back to the attached device.
+    """Attention limits of the target NPU. ATOM accepts twice the extent REBEL does.
 
-    ATOM accepts twice the dynamic-axis extent REBEL does, so the two families carry separate
-    limits. When the family cannot be resolved — compiling on a host without an NPU and without
-    `npu` pinned on the config — the wider ATOM limits apply and the compiler stays the backstop.
+    With no NPU to name — compiling on a host without one and without `npu` pinned on the config —
+    the wider ATOM limits apply and the compiler stays the backstop. A named-but-unknown NPU is a
+    different case and raises: inheriting the wider limits there is exactly the silent compiler
+    abort this guard exists to prevent.
     """
-    npu = npu or (rebel.get_npu_name(0) if rebel.npu_is_available(0) else None)
-    if npu is not None and npu.startswith("RBLN-CR"):
+    npu = resolve_npu_or_none(npu)
+    if npu is None:
+        return ATOM_ATTENTION_LIMITS
+    if npu.startswith("RBLN-CR"):
         return REBEL_ATTENTION_LIMITS
-    return ATOM_ATTENTION_LIMITS
+    if npu.startswith("RBLN-CA"):
+        return ATOM_ATTENTION_LIMITS
+    raise ValueError(f"Unknown npu name: {npu}")
 
 
 def set_default_values(
@@ -82,10 +87,12 @@ def set_default_values(
     if attn_impl is None:
         attn_impl = "eager"
 
+    # Resolve once: the prefill-chunk default and the attention limits below both read it, and
+    # resolving at each use made the result depend on which arguments the caller happened to pass.
+    npu = resolve_npu_or_none(npu)
+
     if prefill_chunk_size is None:
         # RBLN-CR NPUs use a larger prefill chunk for better prefill performance.
-        # Prefer the target NPU pinned on the config; fall back to the locally attached device.
-        npu = npu or rebel.get_npu_name(0)
         prefill_chunk_size = 512 if "RBLN-CR" in (npu or "") else 128
     if prefill_chunk_size % 64 != 0 or prefill_chunk_size <= 0:
         raise ValueError("`prefill_chunk_size` must be a positive integer divisible by 64.")
@@ -117,23 +124,14 @@ def validate_attention_method(
     kvcache_block_size: int,
     max_seq_len: int,
     npu: str | None = None,
-):
+) -> None:
     if attn_impl not in ["eager", "flash_attn"]:
         raise ValueError(f"Unknown `attn_impl` : {attn_impl}. (Available : 'eager', 'flash_attn`)")
 
     limits = get_attention_limits(npu)
 
-    ## Checking Constraints...
     # The device bounds the extent of the KV cache's dynamic axis, which eager attention sets to
     # `max_seq_len` and flash attention to `kvcache_partition_len`. ATOM allows 32k, REBEL 16k.
-
-    # Constraint of eager attention:
-    # - `max_seq_len` <= `limits.max_eager_seq_len`
-
-    # Constraints of flash attention:
-    # 1. `max_seq_len` should be multiple of `partition_len`.
-    # 2. `limits.min_flash_partition_len` <= `partition_len` <= `limits.max_flash_partition_len`.
-    # 3. `max_seq_len` should be at least twice the minimum partition length.
     if attn_impl == "eager" and max_seq_len > limits.max_eager_seq_len:
         raise ValueError(
             f"`max_seq_len` is set to {max_seq_len}, "
@@ -174,10 +172,16 @@ def validate_attention_method(
             )
 
 
-def validate_sliding_window(rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig"):
-    if rbln_config.sliding_window > MAX_SLIDING_WINDOW_SIZE - rbln_config.prefill_chunk_size:
+def validate_sliding_window(rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig") -> None:
+    # A sliding-window cache makes `sliding_window` the dynamic axis, so the same per-family limit
+    # bounds it, less the prefill chunk in flight.
+    limits = get_attention_limits(rbln_config.npu)
+    max_sliding_window = limits.max_sliding_window - rbln_config.prefill_chunk_size
+    if rbln_config.sliding_window > max_sliding_window:
         raise ValueError(
-            f"Sliding window size ({rbln_config.sliding_window}) must be less than {MAX_SLIDING_WINDOW_SIZE} - prefill_chunk_size ({MAX_SLIDING_WINDOW_SIZE - rbln_config.prefill_chunk_size})"
+            f"Sliding window size ({rbln_config.sliding_window}) must be at most {max_sliding_window} on "
+            f"{limits.name} (`max_sliding_window` {limits.max_sliding_window} - `prefill_chunk_size` "
+            f"{rbln_config.prefill_chunk_size})."
         )
 
     if rbln_config.cache_impl == "sliding_window" and rbln_config.use_attention_mask:

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -143,7 +143,8 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             `attn_impl` determines the underlying attention mechanism used by the model.
 
             - **`"eager"`** (Default if `kvcache_partition_len` is not set): Uses the standard PyTorch
-                attention implementation. Suitable for sequences up to a certain limit (e.g., 32,768 tokens).
+                attention implementation. `max_seq_len` is capped by the target NPU — 32,768 tokens on
+                ATOM (`RBLN-CA`) and 16,384 on REBEL (`RBLN-CR`).
             - **`"flash_attn"`**: Utilizes an optimized Flash Attention implementation, beneficial for
                 longer sequences and potentially faster execution. Requires `max_seq_len` to be at least
                 2,048. If `kvcache_partition_len` is specified, `attn_impl` automatically defaults
@@ -159,7 +160,8 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             `kvcache_partition_len` is relevant **only** when `attn_impl` is `"flash_attn"`.
 
             - It defines the length (number of tokens) of each partition within the Key-Value (KV) cache.
-            - Must be between 1,024 and 32,768 (inclusive).
+            - Must be between 1,024 and the target NPU's limit, inclusive — 32,768 on ATOM
+                (`RBLN-CA`) and 16,384 on REBEL (`RBLN-CR`).
             - When using `"flash_attn"`, `max_seq_len` must be a multiple of `kvcache_partition_len`
                 and at least twice its value (`max_seq_len >= 2 * kvcache_partition_len`).
             - If `attn_impl` is `"flash_attn"` and `kvcache_partition_len` is `None`, it defaults to

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -143,13 +143,15 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             `attn_impl` determines the underlying attention mechanism used by the model.
 
             - **`"eager"`** (Default if `kvcache_partition_len` is not set): Uses the standard PyTorch
-                attention implementation. `max_seq_len` is capped by the target NPU — 32,768 tokens on
-                ATOM (`RBLN-CA`) and 16,384 on REBEL (`RBLN-CR`).
+                attention implementation. `max_seq_len` is capped by the target NPU.
             - **`"flash_attn"`**: Utilizes an optimized Flash Attention implementation, beneficial for
                 longer sequences and potentially faster execution. Requires `max_seq_len` to be at least
-                2,048. If `kvcache_partition_len` is specified, `attn_impl` automatically defaults
-                to `"flash_attn"`. When using `"flash_attn"`, `kvcache_block_size` must equal
-                `kvcache_partition_len`.
+                twice the minimum partition length. If `kvcache_partition_len` is specified, `attn_impl`
+                automatically defaults to `"flash_attn"`. When using `"flash_attn"`,
+                `kvcache_block_size` must equal `kvcache_partition_len`.
+
+            Every bound above is per NPU family; `AttentionLimits` in `modeling_attention_utils` is
+            the single source, and the raised `ValueError` names the resolved family and value.
 
             The choice impacts performance and memory usage, especially for long sequences.
             Constraints related to `max_seq_len` and `kvcache_partition_len` apply when using
@@ -160,12 +162,11 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             `kvcache_partition_len` is relevant **only** when `attn_impl` is `"flash_attn"`.
 
             - It defines the length (number of tokens) of each partition within the Key-Value (KV) cache.
-            - Must be between 1,024 and the target NPU's limit, inclusive — 32,768 on ATOM
-                (`RBLN-CA`) and 16,384 on REBEL (`RBLN-CR`).
+            - Must be between the target NPU's minimum and maximum partition length, inclusive.
             - When using `"flash_attn"`, `max_seq_len` must be a multiple of `kvcache_partition_len`
                 and at least twice its value (`max_seq_len >= 2 * kvcache_partition_len`).
             - If `attn_impl` is `"flash_attn"` and `kvcache_partition_len` is `None`, it defaults to
-                the target NPU's default — 16,384 on ATOM (`RBLN-CA`) and 8,192 on REBEL (`RBLN-CR`).
+                the target NPU's default partition length.
 
 
         KV Cache Number of Blocks:

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -165,7 +165,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             - When using `"flash_attn"`, `max_seq_len` must be a multiple of `kvcache_partition_len`
                 and at least twice its value (`max_seq_len >= 2 * kvcache_partition_len`).
             - If `attn_impl` is `"flash_attn"` and `kvcache_partition_len` is `None`, it defaults to
-                16,384.
+                the target NPU's default — 16,384 on ATOM (`RBLN-CA`) and 8,192 on REBEL (`RBLN-CR`).
 
 
         KV Cache Number of Blocks:

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -514,6 +514,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             kvcache_partition_len=rbln_config.kvcache_partition_len,
             kvcache_block_size=rbln_config.kvcache_block_size,
             max_seq_len=rbln_config.max_seq_len,
+            npu=rbln_config.npu,
         )
 
         # Validate kvcache_num_blocks against `num_min_blocks` / `num_full_blocks`.

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -103,9 +103,20 @@ def parse_byte_size(value: int | str) -> int:
     return nbytes
 
 
+def resolve_npu_or_none(npu: str | None = None) -> str | None:
+    """The target NPU: the name pinned on the config, else the attached device's, else None.
+
+    Unlike `_resolve_npu` this does not raise — callers that only pick defaults or bounds must
+    keep working on a host with no NPU attached.
+    """
+    if npu is not None:
+        return npu
+    return rebel.get_npu_name(0) if rebel.npu_is_available(0) else None
+
+
 def npu_is_cr13_or_later(npu: str | None = None) -> bool:
     """Whether the NPU is RBLN-CR13 or later — every CR except CR03 (rebel-compiler's `_is_evt1`)."""
-    npu = npu or (rebel.get_npu_name(0) if rebel.npu_is_available(0) else None)
+    npu = resolve_npu_or_none(npu)
     if not npu:
         return False
     normalized = normalize_npu(npu)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -455,6 +455,38 @@ class TestAttentionLimits:
         with pytest.raises(ValueError, match="out of the"):
             self._validate("flash_attn", 4096, kvcache_partition_len=512, npu=npu)
 
+    @pytest.mark.parametrize("npu,expected_partition_len", [("RBLN-CA22", 16384), ("RBLN-CR13", 8192)])
+    def test_flash_partition_default_is_per_family(self, npu, expected_partition_len):
+        from optimum.rbln.transformers.modeling_attention_utils import set_default_values
+
+        attn_impl, partition_len, block_size, _ = set_default_values(
+            attn_impl="flash_attn", max_seq_len=65536, npu=npu
+        )
+        assert (attn_impl, partition_len, block_size) == ("flash_attn", expected_partition_len, expected_partition_len)
+
+    def test_explicit_partition_len_wins_over_family_default(self):
+        from optimum.rbln.transformers.modeling_attention_utils import set_default_values
+
+        # An explicit `kvcache_partition_len` also promotes eager -> flash_attn; the value must survive that.
+        attn_impl, partition_len, _, _ = set_default_values(
+            kvcache_partition_len=4096, max_seq_len=65536, npu="RBLN-CR13"
+        )
+        assert (attn_impl, partition_len) == ("flash_attn", 4096)
+
+    @pytest.mark.parametrize("npu", ["RBLN-CA22", "RBLN-CR13"])
+    def test_family_default_satisfies_its_own_limits(self, npu):
+        """Each family's default partition must pass the validator it is paired with."""
+        from optimum.rbln.transformers.modeling_attention_utils import get_attention_limits, set_default_values
+
+        limits = get_attention_limits(npu)
+        assert limits.min_flash_partition_len <= limits.default_flash_partition_len <= limits.max_flash_partition_len
+
+        _, partition_len, block_size, _ = set_default_values(
+            attn_impl="flash_attn", max_seq_len=2 * limits.default_flash_partition_len, npu=npu
+        )
+        assert block_size == partition_len
+        self._validate("flash_attn", 2 * partition_len, kvcache_partition_len=partition_len, npu=npu)
+
     def test_falls_back_to_attached_npu(self, monkeypatch):
         monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
         monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -467,7 +467,7 @@ class TestAttentionLimits:
         assert limits.default_flash_partition_len <= limits.max_flash_partition_len
         assert limits.min_flash_max_seq_len == 2 * limits.min_flash_partition_len
 
-    @pytest.mark.parametrize("npu,prefill_chunk_size,bound", [("RBLN-CA22", 128, 32_640), ("RBLN-CR13", 512, 15_872)])
+    @pytest.mark.parametrize("npu,prefill_chunk_size,bound", [("RBLN-CA22", 128, 32_640), ("RBLN-CR13", 512, 32_255)])
     def test_sliding_window_bound(self, npu, prefill_chunk_size, bound):
         from optimum.rbln.transformers.modeling_attention_utils import validate_sliding_window
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -403,6 +403,88 @@ class TestPrefillChunkSizeDefault:
             self._resolve(prefill_chunk_size=invalid_chunk_size, npu="RBLN-CA22")
 
 
+class TestAttentionLimits:
+    """Per-NPU-family bounds on the extent of the KV cache's dynamic axis (ATOM 32k / REBEL 16k)."""
+
+    @staticmethod
+    def _validate(attn_impl, max_seq_len, kvcache_partition_len=None, npu=None):
+        from optimum.rbln.transformers.modeling_attention_utils import validate_attention_method
+
+        validate_attention_method(
+            attn_impl=attn_impl,
+            kvcache_partition_len=kvcache_partition_len,
+            # `set_default_values` derives the block size from the mode's dynamic axis.
+            kvcache_block_size=max_seq_len if attn_impl == "eager" else kvcache_partition_len,
+            max_seq_len=max_seq_len,
+            npu=npu,
+        )
+
+    @pytest.mark.parametrize(
+        "npu,expected",
+        [("RBLN-CA22", "ATOM"), ("RBLN-CA25", "ATOM"), ("RBLN-CR03", "REBEL"), ("RBLN-CR13", "REBEL")],
+    )
+    def test_family_resolution(self, npu, expected):
+        from optimum.rbln.transformers.modeling_attention_utils import get_attention_limits
+
+        assert get_attention_limits(npu).name == expected
+
+    @pytest.mark.parametrize("npu,max_seq_len", [("RBLN-CA22", 32768), ("RBLN-CR13", 16384)])
+    def test_eager_at_the_cap_is_accepted(self, npu, max_seq_len):
+        self._validate("eager", max_seq_len, npu=npu)
+
+    def test_eager_32k_rejected_on_rebel(self):
+        # deploy #1443: eager + 32768 compiles on ATOM but aborts the compiler on REBEL.
+        with pytest.raises(ValueError, match="REBEL limit of 16384"):
+            self._validate("eager", 32768, npu="RBLN-CR13")
+
+    def test_eager_above_cap_rejected_on_atom(self):
+        with pytest.raises(ValueError, match="ATOM limit of 32768"):
+            self._validate("eager", 40960, npu="RBLN-CA22")
+
+    @pytest.mark.parametrize("npu,kvcache_partition_len", [("RBLN-CA22", 32768), ("RBLN-CR13", 16384)])
+    def test_flash_partition_at_the_cap_is_accepted(self, npu, kvcache_partition_len):
+        self._validate("flash_attn", 65536, kvcache_partition_len=kvcache_partition_len, npu=npu)
+
+    def test_flash_partition_32k_rejected_on_rebel(self):
+        with pytest.raises(ValueError, match="REBEL supported range"):
+            self._validate("flash_attn", 65536, kvcache_partition_len=32768, npu="RBLN-CR13")
+
+    @pytest.mark.parametrize("npu", ["RBLN-CA22", "RBLN-CR13"])
+    def test_min_flash_partition_is_shared_by_both_families(self, npu):
+        self._validate("flash_attn", 4096, kvcache_partition_len=1024, npu=npu)
+        with pytest.raises(ValueError, match="out of the"):
+            self._validate("flash_attn", 4096, kvcache_partition_len=512, npu=npu)
+
+    def test_falls_back_to_attached_npu(self, monkeypatch):
+        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
+        monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
+        with pytest.raises(ValueError, match="REBEL limit of 16384"):
+            self._validate("eager", 32768)
+
+    def test_falls_back_to_atom_without_attached_npu(self, monkeypatch):
+        # Compiling on a host without an NPU keeps the wider limits; the compiler stays the backstop.
+        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: False)
+        self._validate("eager", 32768)
+
+    def test_explicit_npu_wins_over_attached_device(self, monkeypatch):
+        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
+        monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
+        self._validate("eager", 32768, npu="RBLN-CA22")
+
+
+def test_attention_limits_npu_wiring():
+    """Compile-time wiring: `rbln_config.npu` flows through `_update_attention_config` into the
+    NPU-aware limits. `update_rbln_config` runs before `get_compiled_model`, so pinning a REBEL
+    target rejects eager 32k without compiling anything."""
+    with pytest.raises(ValueError, match="REBEL limit of 16384"):
+        RBLNLlamaForCausalLM.from_pretrained(
+            "afmck/testing-llama-tiny",
+            export=True,
+            num_hidden_layers=1,
+            rbln_config={"npu": "RBLN-CR03", "create_runtimes": False, "max_seq_len": 32768},
+        )
+
+
 @pytest.mark.skip(reason="Compilation fails: cross-compiling for RBLN-CR03 on a CA25 runner, need to fix it")
 def test_prefill_chunk_size_npu_wiring_e2e(tmp_path):
     """Compile-time wiring: `rbln_config.npu` flows through `_update_attention_config` into the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -428,39 +428,39 @@ class TestAttentionLimits:
 
         assert get_attention_limits(npu).name == expected
 
-    @pytest.mark.parametrize("npu,max_seq_len", [("RBLN-CA22", 32768), ("RBLN-CR13", 16384)])
+    @pytest.mark.parametrize("npu,max_seq_len", [("RBLN-CA22", 32_768), ("RBLN-CR13", 16_384)])
     def test_eager_at_the_cap_is_accepted(self, npu, max_seq_len):
         self._validate("eager", max_seq_len, npu=npu)
 
     def test_eager_32k_rejected_on_rebel(self):
-        # deploy #1443: eager + 32768 compiles on ATOM but aborts the compiler on REBEL.
+        # deploy #1443: eager + 32_768 compiles on ATOM but aborts the compiler on REBEL.
         with pytest.raises(ValueError, match="REBEL limit of 16384"):
-            self._validate("eager", 32768, npu="RBLN-CR13")
+            self._validate("eager", 32_768, npu="RBLN-CR13")
 
     def test_eager_above_cap_rejected_on_atom(self):
         with pytest.raises(ValueError, match="ATOM limit of 32768"):
-            self._validate("eager", 40960, npu="RBLN-CA22")
+            self._validate("eager", 40_960, npu="RBLN-CA22")
 
-    @pytest.mark.parametrize("npu,kvcache_partition_len", [("RBLN-CA22", 32768), ("RBLN-CR13", 16384)])
+    @pytest.mark.parametrize("npu,kvcache_partition_len", [("RBLN-CA22", 32_768), ("RBLN-CR13", 16_384)])
     def test_flash_partition_at_the_cap_is_accepted(self, npu, kvcache_partition_len):
-        self._validate("flash_attn", 65536, kvcache_partition_len=kvcache_partition_len, npu=npu)
+        self._validate("flash_attn", 65_536, kvcache_partition_len=kvcache_partition_len, npu=npu)
 
     def test_flash_partition_32k_rejected_on_rebel(self):
         with pytest.raises(ValueError, match="REBEL supported range"):
-            self._validate("flash_attn", 65536, kvcache_partition_len=32768, npu="RBLN-CR13")
+            self._validate("flash_attn", 65_536, kvcache_partition_len=32_768, npu="RBLN-CR13")
 
     @pytest.mark.parametrize("npu", ["RBLN-CA22", "RBLN-CR13"])
     def test_min_flash_partition_is_shared_by_both_families(self, npu):
-        self._validate("flash_attn", 4096, kvcache_partition_len=1024, npu=npu)
+        self._validate("flash_attn", 4_096, kvcache_partition_len=1_024, npu=npu)
         with pytest.raises(ValueError, match="out of the"):
-            self._validate("flash_attn", 4096, kvcache_partition_len=512, npu=npu)
+            self._validate("flash_attn", 4_096, kvcache_partition_len=512, npu=npu)
 
-    @pytest.mark.parametrize("npu,expected_partition_len", [("RBLN-CA22", 16384), ("RBLN-CR13", 8192)])
+    @pytest.mark.parametrize("npu,expected_partition_len", [("RBLN-CA22", 16_384), ("RBLN-CR13", 8_192)])
     def test_flash_partition_default_is_per_family(self, npu, expected_partition_len):
         from optimum.rbln.transformers.modeling_attention_utils import set_default_values
 
         attn_impl, partition_len, block_size, _ = set_default_values(
-            attn_impl="flash_attn", max_seq_len=65536, npu=npu
+            attn_impl="flash_attn", max_seq_len=65_536, npu=npu
         )
         assert (attn_impl, partition_len, block_size) == ("flash_attn", expected_partition_len, expected_partition_len)
 
@@ -469,9 +469,9 @@ class TestAttentionLimits:
 
         # An explicit `kvcache_partition_len` also promotes eager -> flash_attn; the value must survive that.
         attn_impl, partition_len, _, _ = set_default_values(
-            kvcache_partition_len=4096, max_seq_len=65536, npu="RBLN-CR13"
+            kvcache_partition_len=4_096, max_seq_len=65_536, npu="RBLN-CR13"
         )
-        assert (attn_impl, partition_len) == ("flash_attn", 4096)
+        assert (attn_impl, partition_len) == ("flash_attn", 4_096)
 
     @pytest.mark.parametrize("npu", ["RBLN-CA22", "RBLN-CR13"])
     def test_family_default_satisfies_its_own_limits(self, npu):
@@ -491,17 +491,55 @@ class TestAttentionLimits:
         monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
         monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
         with pytest.raises(ValueError, match="REBEL limit of 16384"):
-            self._validate("eager", 32768)
+            self._validate("eager", 32_768)
 
     def test_falls_back_to_atom_without_attached_npu(self, monkeypatch):
         # Compiling on a host without an NPU keeps the wider limits; the compiler stays the backstop.
         monkeypatch.setattr(rebel, "npu_is_available", lambda *args: False)
-        self._validate("eager", 32768)
+        self._validate("eager", 32_768)
+
+    def test_unknown_npu_raises_instead_of_inheriting_wider_limits(self):
+        from optimum.rbln.transformers.modeling_attention_utils import get_attention_limits
+
+        with pytest.raises(ValueError, match="Unknown npu name"):
+            get_attention_limits("RBLN-XX99")
 
     def test_explicit_npu_wins_over_attached_device(self, monkeypatch):
         monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
         monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
-        self._validate("eager", 32768, npu="RBLN-CA22")
+        self._validate("eager", 32_768, npu="RBLN-CA22")
+
+
+class TestSlidingWindowLimit:
+    """`validate_sliding_window` bounds the third axis from the same per-family record."""
+
+    @staticmethod
+    def _validate(sliding_window, npu, prefill_chunk_size):
+        from optimum.rbln.transformers.modeling_attention_utils import validate_sliding_window
+
+        validate_sliding_window(
+            RBLNLlamaForCausalLMConfig(
+                max_seq_len=8_192,
+                sliding_window=sliding_window,
+                prefill_chunk_size=prefill_chunk_size,
+                npu=npu,
+            )
+        )
+
+    def test_atom_bound_is_unchanged(self):
+        self._validate(32_640, npu="RBLN-CA22", prefill_chunk_size=128)
+        with pytest.raises(ValueError, match="at most 32640 on ATOM"):
+            self._validate(32_641, npu="RBLN-CA22", prefill_chunk_size=128)
+
+    def test_rebel_bound_is_the_family_max_less_the_prefill_chunk(self):
+        self._validate(15_872, npu="RBLN-CR13", prefill_chunk_size=512)
+        with pytest.raises(ValueError, match="at most 15872 on REBEL"):
+            self._validate(16_384, npu="RBLN-CR13", prefill_chunk_size=512)
+
+    def test_rebel_rejects_what_the_global_bound_admitted(self):
+        # 32_256 sat inside the old global bound (32_768 - 512) on every target.
+        with pytest.raises(ValueError, match="at most 15872 on REBEL"):
+            self._validate(32_256, npu="RBLN-CR13", prefill_chunk_size=512)
 
 
 def test_attention_limits_npu_wiring():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -413,133 +413,77 @@ class TestAttentionLimits:
         validate_attention_method(
             attn_impl=attn_impl,
             kvcache_partition_len=kvcache_partition_len,
-            # `set_default_values` derives the block size from the mode's dynamic axis.
             kvcache_block_size=max_seq_len if attn_impl == "eager" else kvcache_partition_len,
             max_seq_len=max_seq_len,
             npu=npu,
         )
 
-    @pytest.mark.parametrize(
-        "npu,expected",
-        [("RBLN-CA22", "ATOM"), ("RBLN-CA25", "ATOM"), ("RBLN-CR03", "REBEL"), ("RBLN-CR13", "REBEL")],
-    )
-    def test_family_resolution(self, npu, expected):
+    def test_family_resolution(self, monkeypatch):
         from optimum.rbln.transformers.modeling_attention_utils import get_attention_limits
 
-        assert get_attention_limits(npu).name == expected
+        assert get_attention_limits("RBLN-CA22").name == "ATOM"
+        assert get_attention_limits("RBLN-CR13").name == "REBEL"
+        with pytest.raises(ValueError, match="Unknown npu name"):
+            get_attention_limits("RBLN-XX99")
 
-    @pytest.mark.parametrize("npu,max_seq_len", [("RBLN-CA22", 32_768), ("RBLN-CR13", 16_384)])
-    def test_eager_at_the_cap_is_accepted(self, npu, max_seq_len):
-        self._validate("eager", max_seq_len, npu=npu)
+        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
+        monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
+        assert get_attention_limits().name == "REBEL"
+        assert get_attention_limits("RBLN-CA22").name == "ATOM"
 
-    def test_eager_32k_rejected_on_rebel(self):
-        # deploy #1443: eager + 32_768 compiles on ATOM but aborts the compiler on REBEL.
-        with pytest.raises(ValueError, match="REBEL limit of 16384"):
-            self._validate("eager", 32_768, npu="RBLN-CR13")
+        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: False)
+        assert get_attention_limits().name == "ATOM"
 
-    def test_eager_above_cap_rejected_on_atom(self):
-        with pytest.raises(ValueError, match="ATOM limit of 32768"):
-            self._validate("eager", 40_960, npu="RBLN-CA22")
+    @pytest.mark.parametrize("npu,cap", [("RBLN-CA22", 32_768), ("RBLN-CR13", 16_384)])
+    def test_eager_max_seq_len_cap(self, npu, cap):
+        # REBEL rejecting 32_768 here is deploy #1443, which aborted the compiler instead.
+        self._validate("eager", cap, npu=npu)
+        with pytest.raises(ValueError, match=f"limit of {cap}"):
+            self._validate("eager", 2 * cap, npu=npu)
 
-    @pytest.mark.parametrize("npu,kvcache_partition_len", [("RBLN-CA22", 32_768), ("RBLN-CR13", 16_384)])
-    def test_flash_partition_at_the_cap_is_accepted(self, npu, kvcache_partition_len):
-        self._validate("flash_attn", 65_536, kvcache_partition_len=kvcache_partition_len, npu=npu)
-
-    def test_flash_partition_32k_rejected_on_rebel(self):
-        with pytest.raises(ValueError, match="REBEL supported range"):
-            self._validate("flash_attn", 65_536, kvcache_partition_len=32_768, npu="RBLN-CR13")
-
-    @pytest.mark.parametrize("npu", ["RBLN-CA22", "RBLN-CR13"])
-    def test_min_flash_partition_is_shared_by_both_families(self, npu):
-        self._validate("flash_attn", 4_096, kvcache_partition_len=1_024, npu=npu)
-        with pytest.raises(ValueError, match="out of the"):
+    @pytest.mark.parametrize("npu,cap", [("RBLN-CA22", 32_768), ("RBLN-CR13", 16_384)])
+    def test_flash_partition_len_range(self, npu, cap):
+        self._validate("flash_attn", 2 * cap, kvcache_partition_len=cap, npu=npu)
+        with pytest.raises(ValueError, match="supported range"):
+            self._validate("flash_attn", 4 * cap, kvcache_partition_len=2 * cap, npu=npu)
+        with pytest.raises(ValueError, match="supported range"):
             self._validate("flash_attn", 4_096, kvcache_partition_len=512, npu=npu)
 
-    @pytest.mark.parametrize("npu,expected_partition_len", [("RBLN-CA22", 16_384), ("RBLN-CR13", 8_192)])
-    def test_flash_partition_default_is_per_family(self, npu, expected_partition_len):
+    @pytest.mark.parametrize("npu,default", [("RBLN-CA22", 16_384), ("RBLN-CR13", 8_192)])
+    def test_flash_partition_len_default(self, npu, default):
         from optimum.rbln.transformers.modeling_attention_utils import set_default_values
 
         attn_impl, partition_len, block_size, _ = set_default_values(
             attn_impl="flash_attn", max_seq_len=65_536, npu=npu
         )
-        assert (attn_impl, partition_len, block_size) == ("flash_attn", expected_partition_len, expected_partition_len)
-
-    def test_explicit_partition_len_wins_over_family_default(self):
-        from optimum.rbln.transformers.modeling_attention_utils import set_default_values
-
-        # An explicit `kvcache_partition_len` also promotes eager -> flash_attn; the value must survive that.
-        attn_impl, partition_len, _, _ = set_default_values(
-            kvcache_partition_len=4_096, max_seq_len=65_536, npu="RBLN-CR13"
-        )
-        assert (attn_impl, partition_len) == ("flash_attn", 4_096)
+        assert (attn_impl, partition_len, block_size) == ("flash_attn", default, default)
 
     @pytest.mark.parametrize("npu", ["RBLN-CA22", "RBLN-CR13"])
-    def test_family_default_satisfies_its_own_limits(self, npu):
-        """Each family's default partition must pass the validator it is paired with."""
-        from optimum.rbln.transformers.modeling_attention_utils import get_attention_limits, set_default_values
-
-        limits = get_attention_limits(npu)
-        assert limits.min_flash_partition_len <= limits.default_flash_partition_len <= limits.max_flash_partition_len
-
-        _, partition_len, block_size, _ = set_default_values(
-            attn_impl="flash_attn", max_seq_len=2 * limits.default_flash_partition_len, npu=npu
-        )
-        assert block_size == partition_len
-        self._validate("flash_attn", 2 * partition_len, kvcache_partition_len=partition_len, npu=npu)
-
-    def test_falls_back_to_attached_npu(self, monkeypatch):
-        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
-        monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
-        with pytest.raises(ValueError, match="REBEL limit of 16384"):
-            self._validate("eager", 32_768)
-
-    def test_falls_back_to_atom_without_attached_npu(self, monkeypatch):
-        # Compiling on a host without an NPU keeps the wider limits; the compiler stays the backstop.
-        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: False)
-        self._validate("eager", 32_768)
-
-    def test_unknown_npu_raises_instead_of_inheriting_wider_limits(self):
+    def test_record_is_self_consistent(self, npu):
         from optimum.rbln.transformers.modeling_attention_utils import get_attention_limits
 
-        with pytest.raises(ValueError, match="Unknown npu name"):
-            get_attention_limits("RBLN-XX99")
+        limits = get_attention_limits(npu)
+        assert limits.min_flash_partition_len <= limits.default_flash_partition_len
+        assert limits.default_flash_partition_len <= limits.max_flash_partition_len
+        assert limits.min_flash_max_seq_len == 2 * limits.min_flash_partition_len
 
-    def test_explicit_npu_wins_over_attached_device(self, monkeypatch):
-        monkeypatch.setattr(rebel, "npu_is_available", lambda *args: True)
-        monkeypatch.setattr(rebel, "get_npu_name", lambda *args: "RBLN-CR13")
-        self._validate("eager", 32_768, npu="RBLN-CA22")
-
-
-class TestSlidingWindowLimit:
-    """`validate_sliding_window` bounds the third axis from the same per-family record."""
-
-    @staticmethod
-    def _validate(sliding_window, npu, prefill_chunk_size):
+    @pytest.mark.parametrize("npu,prefill_chunk_size,bound", [("RBLN-CA22", 128, 32_640), ("RBLN-CR13", 512, 15_872)])
+    def test_sliding_window_bound(self, npu, prefill_chunk_size, bound):
         from optimum.rbln.transformers.modeling_attention_utils import validate_sliding_window
 
-        validate_sliding_window(
-            RBLNLlamaForCausalLMConfig(
-                max_seq_len=8_192,
-                sliding_window=sliding_window,
-                prefill_chunk_size=prefill_chunk_size,
-                npu=npu,
+        def validate(sliding_window):
+            validate_sliding_window(
+                RBLNLlamaForCausalLMConfig(
+                    max_seq_len=8_192,
+                    sliding_window=sliding_window,
+                    prefill_chunk_size=prefill_chunk_size,
+                    npu=npu,
+                )
             )
-        )
 
-    def test_atom_bound_is_unchanged(self):
-        self._validate(32_640, npu="RBLN-CA22", prefill_chunk_size=128)
-        with pytest.raises(ValueError, match="at most 32640 on ATOM"):
-            self._validate(32_641, npu="RBLN-CA22", prefill_chunk_size=128)
-
-    def test_rebel_bound_is_the_family_max_less_the_prefill_chunk(self):
-        self._validate(15_872, npu="RBLN-CR13", prefill_chunk_size=512)
-        with pytest.raises(ValueError, match="at most 15872 on REBEL"):
-            self._validate(16_384, npu="RBLN-CR13", prefill_chunk_size=512)
-
-    def test_rebel_rejects_what_the_global_bound_admitted(self):
-        # 32_256 sat inside the old global bound (32_768 - 512) on every target.
-        with pytest.raises(ValueError, match="at most 15872 on REBEL"):
-            self._validate(32_256, npu="RBLN-CR13", prefill_chunk_size=512)
+        validate(bound)
+        with pytest.raises(ValueError, match=f"at most {bound}"):
+            validate(bound + 1)
 
 
 def test_attention_limits_npu_wiring():


### PR DESCRIPTION
## Issue

One set of globals bounded every target — `DEFAULT_MAX_EAGER_ATTN_SEQUENCE_LENGTH`,
`MAX_FLASH_ATTN_PARTITION_LENGTH`, `MIN_FLASH_ATTN_*`, `DEFAULT_FLASH_ATTN_PARTITION_LENGTH`,
`MAX_SLIDING_WINDOW_SIZE`.

They match ATOM. On REBEL they are a tier too wide, so the config passes Python validation and the
native compiler aborts — `exit 134`, core dump, no Python traceback. deploy nightly #1443: 15 REBEL
32k suites died there while the ATOM twins compiled.

The bounded quantity is the extent of the KV cache's dynamic axis, and each attention mode makes a
different parameter that axis: `max_seq_len` (eager), `kvcache_partition_len` (flash),
`sliding_window` (sliding-window cache). `validate_attention_method` had no `npu` to see the family
with.

Refs #720. Supersedes #721 (closed).

## Resolution

`AttentionLimits` — one frozen record per family, resolved from the target NPU:

| bounded parameter | ATOM (`RBLN-CA`) | REBEL (`RBLN-CR`) |
|---|---|---|
| eager `max_seq_len` | ≤ 32,768 | ≤ 16,384 |
| flash `kvcache_partition_len` | 1,024 – 32,768 | 1,024 – 16,384 |
| flash default partition | 16,384 | 8,192 |
| `sliding_window` (− prefill chunk) | ≤ 32,640 | ≤ 32,255 |

- `get_attention_limits(npu)`: `RBLN-CR*` → REBEL, `RBLN-CA*` → ATOM, no NPU → ATOM (the compiler
  stays the backstop), unknown name → `ValueError` rather than the wider limits.
- `validate_attention_method` gains an optional `npu`, wired from its single caller; every message
  names the resolved family and value.
- `min_flash_max_seq_len` is derived (`2 × min_flash_partition_len`), and one
  `resolve_npu_or_none` in `runtime_utils` replaces three drifted copies of the npu resolution.

ATOM behaviour is unchanged throughout.

**Why REBEL 16,384 and not the measured 32,767 ceiling** — both bounded parameters are powers of two
in practice (`kvcache_partition_len` must divide `max_seq_len`; eager's bound *is* `max_seq_len`), so
16,384 is the largest usable value under it. Tradeoff: eager `max_seq_len` in (16,384, 32,767]
compiles on REBEL today and is now rejected.

**Why the default halves to 8,192** — at 16,384 a REBEL default flash config sat exactly on the cap,
so the only valid `max_seq_len` was 32,768 or more.

**Why `sliding_window` keeps the hard ceiling (32,767) instead of 16,384** — the grid argument does
not reach that axis. `sliding_window` comes from the model config and has to divide nothing, so the
INT16 ceiling is its only bound; `max_sliding_window` is 32,768 on ATOM and 32,767 on REBEL, exactly
the two measured ceilings, and the REBEL bound moves by one token rather than a tier.

## Verification

- `TestAttentionLimits`, 6 functions — one per contract clause: family resolution (both families,
  unknown-npu raise, attached-device fallback, pinned target wins), the eager cap, the flash
  partition range, the per-family default, the record's internal consistency, the sliding-window bound.
- `test_attention_limits_npu_wiring`: a pinned REBEL target rejects eager 32k before
  `get_compiled_model` runs, so `rbln_config.npu` provably reaches the validator without compiling.
- Local: every assertion above run against the real module; `ruff format --check .` and
  `ruff check .` (0.15.4, as locked) clean.

## Follow-up

Auto-promoting an unset `attn_impl` to `flash_attn` above the eager cap went away with #721. It is
worth its own PR, with the trigger read from `limits.max_eager_seq_len` rather than a hardcoded
32,768; branch `fix/cr13-eager-32k-flash-default` is kept for it.
