### PR TITLE
other: ci - move PR gates and pytest to Obedients, drop the GHA jobs they replace

### DIFF
--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -11,6 +11,19 @@ env:
   UV_INDEX_STRATEGY: "unsafe-best-match"
   OPTIMUM_RBLN_TEST_LEVEL: "default"
 
+# Run the suites only when the PR touches something that can change their result.
+# Honored because .buildkite/pr.yml uploads this file with --git-diff-base; the
+# commit status is still reported when every step is skipped.
+_if_changed: &if_changed
+  include:
+    - ".buildkite/**"
+    - ".github/scripts/test_cli.py"
+    - ".github/version.yaml"
+    - "pyproject.toml"
+    - "src/**"
+    - "tests/**"
+    - "uv.lock"
+
 _secrets: &secrets
   UV_INDEX_REBELLIONS_USERNAME: REBEL_SW_DEV_USERNAME
   UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
@@ -36,6 +49,7 @@ _npu: &npu
 
 steps:
   - label: ":pytest: config"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -45,6 +59,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh config"
 
   - label: ":pytest: cli-basic"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -54,55 +69,61 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh cli-basic"
 
   - label: ":pytest: transformers"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     command:
       - *sync
       - "bash .buildkite/scripts/run-suite.sh transformers"
 
   - label: ":pytest: diffusers"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     command:
       - *sync
       - "bash .buildkite/scripts/run-suite.sh diffusers"
 
   - label: ":pytest: llm 1/4"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     command:
       - *sync
       - "bash .buildkite/scripts/run-suite.sh llm 1"
 
   - label: ":pytest: llm 2/4"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     command:
       - *sync
       - "bash .buildkite/scripts/run-suite.sh llm 2"
 
   - label: ":pytest: llm 3/4"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     command:
       - *sync
       - "bash .buildkite/scripts/run-suite.sh llm 3"
 
   - label: ":pytest: llm 4/4"
+    if_changed: *if_changed
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     command:
       - *sync
       - "bash .buildkite/scripts/run-suite.sh llm 4"

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -11,18 +11,72 @@ env:
   UV_INDEX_STRATEGY: "unsafe-best-match"
   OPTIMUM_RBLN_TEST_LEVEL: "default"
 
-# Run the suites only when the PR touches something that can change their result.
+# Run a suite only when the PR touches something that can change its result.
 # Honored because .buildkite/pr.yml uploads this file with --git-diff-base; the
 # commit status is still reported when every step is skipped.
-_if_changed: &if_changed
+#
+# Only the safe split is encoded: transformers/ imports diffusers/ solely under
+# TYPE_CHECKING (clip, t5), so those suites can ignore diffusers/ changes. The
+# reverse is not true -- the diffusers pipelines use CLIP, T5, SigLIP and Qwen3
+# from transformers/ -- so diffusers, config and cli-basic run on any src change.
+_if_changed_config: &if_changed_config
   include:
     - ".buildkite/**"
-    - ".github/scripts/test_cli.py"
     - ".github/version.yaml"
     - "pyproject.toml"
-    - "src/**"
-    - "tests/**"
     - "uv.lock"
+    - "src/**"
+    - "tests/__init__.py"
+    - "tests/test_base.py"
+    - "tests/test_config.py"
+
+_if_changed_cli: &if_changed_cli
+  include:
+    - ".buildkite/**"
+    - ".github/version.yaml"
+    - "pyproject.toml"
+    - "uv.lock"
+    - "src/**"
+    - "tests/__init__.py"
+    - "tests/test_base.py"
+    - ".github/scripts/test_cli.py"
+
+_if_changed_diffusers: &if_changed_diffusers
+  include:
+    - ".buildkite/**"
+    - ".github/version.yaml"
+    - "pyproject.toml"
+    - "uv.lock"
+    - "src/**"
+    - "tests/__init__.py"
+    - "tests/test_base.py"
+    - "tests/test_diffusers.py"
+
+_if_changed_transformers: &if_changed_transformers
+  include:
+    - ".buildkite/**"
+    - ".github/version.yaml"
+    - "pyproject.toml"
+    - "uv.lock"
+    - "src/**"
+    - "tests/__init__.py"
+    - "tests/test_base.py"
+    - "tests/test_transformers.py"
+  exclude:
+    - "src/optimum/rbln/diffusers/**"
+
+_if_changed_llm: &if_changed_llm
+  include:
+    - ".buildkite/**"
+    - ".github/version.yaml"
+    - "pyproject.toml"
+    - "uv.lock"
+    - "src/**"
+    - "tests/__init__.py"
+    - "tests/test_base.py"
+    - "tests/test_llm.py"
+  exclude:
+    - "src/optimum/rbln/diffusers/**"
 
 _secrets: &secrets
   UV_INDEX_REBELLIONS_USERNAME: REBEL_SW_DEV_USERNAME
@@ -49,7 +103,7 @@ _npu: &npu
 
 steps:
   - label: ":pytest: config"
-    if_changed: *if_changed
+    if_changed: *if_changed_config
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -59,7 +113,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh config"
 
   - label: ":pytest: cli-basic"
-    if_changed: *if_changed
+    if_changed: *if_changed_cli
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -69,7 +123,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh cli-basic"
 
   - label: ":pytest: transformers"
-    if_changed: *if_changed
+    if_changed: *if_changed_transformers
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -79,7 +133,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh transformers"
 
   - label: ":pytest: diffusers"
-    if_changed: *if_changed
+    if_changed: *if_changed_diffusers
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -89,7 +143,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh diffusers"
 
   - label: ":pytest: llm 1/4"
-    if_changed: *if_changed
+    if_changed: *if_changed_llm
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -99,7 +153,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh llm 1"
 
   - label: ":pytest: llm 2/4"
-    if_changed: *if_changed
+    if_changed: *if_changed_llm
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -109,7 +163,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh llm 2"
 
   - label: ":pytest: llm 3/4"
-    if_changed: *if_changed
+    if_changed: *if_changed_llm
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets
@@ -119,7 +173,7 @@ steps:
       - "bash .buildkite/scripts/run-suite.sh llm 3"
 
   - label: ":pytest: llm 4/4"
-    if_changed: *if_changed
+    if_changed: *if_changed_llm
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     resources: *npu
     secrets: *secrets

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -1,5 +1,10 @@
 # Entry pipeline for PR builds. Gates run first; the pytest pipeline is uploaded
-# only after they pass, with --git-diff-base so if_changed can be used later.
+# only after they pass, with --git-diff-base so if_changed in that pipeline works.
+env:
+  UV_CACHE_DIR: "/mnt/uv_cache"
+  UV_LINK_MODE: "symlink"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+
 steps:
   - label: ":closed_lock_with_key: team-member gate"
     image: "${DEVTOOLS_DOCKER_IMAGE}"
@@ -8,6 +13,27 @@ steps:
     command:
       - "bash .buildkite/scripts/gate-team-member.sh"
 
+  # Same checks as .github/workflows/check_code_quality.yml.
+  - label: ":mag: ruff"
+    notify:
+      - github_commit_status:
+          context: "[OB] code quality"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    command:
+      - "uv sync --locked --python 3.12 --group quality --no-install-project"
+      - "uv run --no-sync ruff format --check ."
+      - "uv run --no-sync ruff check ."
+
+  # Same check as .github/workflows/test-docstrings.yml.
+  - label: ":page_facing_up: docstrings"
+    notify:
+      - github_commit_status:
+          context: "[OB] docstrings"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    command:
+      - "bash .buildkite/scripts/check-docstrings.sh"
+
+  # All gates must pass before the NPU pipeline is even uploaded.
   - wait: ~
 
   - label: ":sparkles: upload pytest"

--- a/.buildkite/scripts/check-docstrings.sh
+++ b/.buildkite/scripts/check-docstrings.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Mirrors .github/workflows/test-docstrings.yml: check that mkdocstrings can parse
+# the src/*.py files this PR changes. DOCSTRINGS_ALL_FILES=1 checks every file.
+set -euo pipefail
+
+base="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}"
+if [ "${DOCSTRINGS_ALL_FILES:-}" = "1" ]; then
+  files=$(find src -name '*.py' -type f | sort)
+else
+  git fetch -q origin "$base"
+  files=$(git diff --name-only "origin/${base}...HEAD" | grep '\.py$' | grep '^src/' || true)
+fi
+
+exclude=(
+  src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
+  src/optimum/rbln/transformers/models/t5/modeling_t5.py
+)
+selected=()
+for f in $files; do
+  for e in "${exclude[@]}"; do
+    if [ "$f" = "$e" ]; then echo "skip excluded: $f"; continue 2; fi
+  done
+  [ -f "$f" ] && selected+=("$f")
+done
+if [ ${#selected[@]} -eq 0 ]; then
+  echo "No Python files to test"
+  exit 0
+fi
+
+echo "--- :package: mkdocs env"
+uv venv -q --python 3.12 /tmp/docstrings-venv
+uv pip install -q --python /tmp/docstrings-venv mkdocs mkdocs-material mkdocstrings mkdocstrings-python
+export PATH="/tmp/docstrings-venv/bin:$PATH"
+
+echo "--- :page_facing_up: ${#selected[@]} files"
+printf '%s\n' "${selected[@]}" | xargs -P 16 -n 1 sh -c \
+  'python .github/scripts/validate_docstrings.py "$0" && echo "ok $0" || { echo "FAILED $0"; exit 1; }'
+echo "All docstring tests passed"

--- a/.buildkite/scripts/check-docstrings.sh
+++ b/.buildkite/scripts/check-docstrings.sh
@@ -11,8 +11,9 @@ else
   files=$(git diff --name-only "origin/${base}...HEAD" | grep '\.py$' | grep '^src/' || true)
 fi
 
+# modeling_t5.py links to ../../../index.md, which the throwaway mkdocs project
+# cannot resolve; drop this once the link is absolute.
 exclude=(
-  src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
   src/optimum/rbln/transformers/models/t5/modeling_t5.py
 )
 selected=()

--- a/.github/workflows/rbln_trigger_on_pr.yaml
+++ b/.github/workflows/rbln_trigger_on_pr.yaml
@@ -62,17 +62,10 @@ jobs:
             echo "No [slack-report] found, continuing without reporting slack"
           fi
 
-  check-code-quality:
-    uses: ./.github/workflows/check_code_quality.yml
-    
-  test-docstrings:
-    uses: ./.github/workflows/test-docstrings.yml
-
   load-version:
     runs-on: rbln-sw-k8s-4c-32gb
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
-    needs: [check-code-quality, test-docstrings]
     outputs:
       compiler_version: ${{ steps.get_version.outputs.compiler_version }}
     steps:
@@ -120,7 +113,6 @@ jobs:
     runs-on: rbln-sw-k8s-4c-32gb
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
-    needs: [check-code-quality, test-docstrings]
     outputs:
       is_team_member: ${{ steps.check_member.outputs.IS_TEAM_MEMBER }}
     steps:
@@ -143,19 +135,6 @@ jobs:
             echo "IS_TEAM_MEMBER=false" >> $GITHUB_OUTPUT
           fi
 
-  # Default PR test if not Dependency update
-  optimum-rbln-pytest:
-    needs: [check-code-quality, test-docstrings, load-version, check-team-member, check-pytest-full]
-    if: |
-      needs.check-pytest-full.outputs.should_full_test != 'true' &&
-      needs.check-team-member.outputs.is_team_member == 'true'
-    uses: ./.github/workflows/rbln_optimum_pytest.yaml
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}
-      rebel_compiler_version: ${{ needs.load-version.outputs.compiler_version }}
-      test_level: "default"
-    secrets: inherit
-
   # Full Schedule test if Dependency update
   optimum-rbln-full-pytest:
     needs: [load-version, check-team-member, check-pytest-full, check-slack-report]
@@ -169,7 +148,7 @@ jobs:
     secrets: inherit
 
   slack-report:
-    needs: [optimum-rbln-full-pytest,optimum-rbln-pytest, bc-inference, load-version, check-slack-report]
+    needs: [optimum-rbln-full-pytest, bc-inference, load-version, check-slack-report]
     if: |
       always() &&
       needs.check-slack-report.outputs.should_slack_report == 'true'
@@ -183,7 +162,7 @@ jobs:
       transformers_version: ${{ needs.check-pytest-full.outputs.should_full_test == 'true' && needs.optimum-rbln-full-pytest.outputs.transformers_version || 'default' }}
       diffusers_version: ${{ needs.check-pytest-full.outputs.should_full_test == 'true' && needs.optimum-rbln-full-pytest.outputs.diffusers_version || 'default' }}
       bc_result: ${{ needs.bc-inference.result }}
-      pytest_job_group: ${{ needs.check-pytest-full.outputs.should_full_test == 'true' && 'optimum-rbln-full-pytest' || 'optimum-rbln-pytest' }}
+      pytest_job_group: "optimum-rbln-full-pytest"
       bc_pytest_job_group: "bc-inference"
       use_playground_channel: true
     secrets: inherit


### PR DESCRIPTION
## Summary
Phase 2 of moving optimum-rbln CI onto Obedients (follows #728).

- `.buildkite/pr.yml`: two more gate steps next to the team-member gate, mirroring the GHA workflows they will replace:
  - `[OB] code quality` — `ruff format --check` + `ruff check` from the locked `quality` group (as `check_code_quality.yml`).
  - `[OB] docstrings` — `scripts/check-docstrings.sh` runs `validate_docstrings.py` over the `src/**/*.py` files changed against the PR base, same exclusions and parallelism as `test-docstrings.yml`. `DOCSTRINGS_ALL_FILES=1` checks every file (for the nightly later).
- `.buildkite/pipelines/pytest/pipeline.yml`: `if_changed` per suite. Every suite runs on changes under `src/`, `pyproject.toml`, `uv.lock`, `.github/version.yaml`, `.buildkite/` or its own test file (`tests/test_base.py` counts for all). `transformers` and `llm` additionally ignore `src/optimum/rbln/diffusers/**`, since `transformers/` imports `diffusers/` only under `TYPE_CHECKING`; the reverse is not encoded because the diffusers pipelines use CLIP, T5, SigLIP and Qwen3. A docs-only PR skips all suites while the `[OB] Optimum-RBLN pytest` status is still reported.
- Step timeout 120 → 60 minutes (longest suite so far: 14 min).
- `.github/workflows/rbln_trigger_on_pr.yaml`: drop the GHA jobs the above replaces — `check-code-quality`, `test-docstrings` and the default `optimum-rbln-pytest` matrix. The reusable workflow files stay: the nightly still calls the first two, and full test / BC still call `rbln_optimum_pytest.yaml`. Dependency PRs (`[pytest-full]`) keep their GHA path.
- Docstring check: `modeling_llava_next.py` is no longer excluded (it parses cleanly). `modeling_t5.py` stays excluded until #732 lands.

## Not in this PR
Full test (`[pytest-full]`), BC and the nightly stay on GHA until Phase 3. `dev` has no required status checks configured, so there is nothing to switch.

## Test plan
- [x] `[OB] code quality` and `[OB] docstrings` appear on this PR and pass ([build #9](https://obedients.k8s.rebellions.in/orgs/main/pipelines/optimum-rbln-pr-ci/builds/9))
- [x] Suites run here (this PR touches `.buildkite/`), all pass (build #9)
- [ ] A docs-only PR skips the suites but still gets the `[OB] Optimum-RBLN pytest` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

