### PR TITLE
doc: make the T5 tensor-parallel docstring link absolute and drop the docstring-check exclusions

### DIFF
--- a/.github/workflows/test-docstrings.yml
+++ b/.github/workflows/test-docstrings.yml
@@ -78,10 +78,7 @@ jobs:
         FILES='${{ steps.changed-files.outputs.files }}'
         
         # Exclude files (hardcoded)
-        EXCLUDE_FILES=(
-          "src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py"
-          "src/optimum/rbln/transformers/models/t5/modeling_t5.py"
-        )
+        EXCLUDE_FILES=()
         
         # Filter out excluded files
         FILTERED_FILES=""

--- a/src/optimum/rbln/transformers/models/t5/modeling_t5.py
+++ b/src/optimum/rbln/transformers/models/t5/modeling_t5.py
@@ -51,7 +51,7 @@ class RBLNT5EncoderModel(RBLNTransformerEncoderForFeatureExtraction):
 
     Important Note:
         This model supports various sizes of the T5EncoderModel. For optimal performance, it is highly recommended to adjust the tensor parallelism setting
-        based on the model size. Please refer to the [Optimum RBLN Overview](../../../index.md) for guidance on choosing the appropriate tensor parallelism size for your model.
+        based on the model size. Please refer to the [Optimum RBLN Overview](https://docs.rbln.ai/software/optimum/optimum_rbln.html) for guidance on choosing the appropriate tensor parallelism size for your model.
 
     Examples:
         ```python
@@ -96,7 +96,7 @@ class RBLNT5ForConditionalGeneration(RBLNModelForSeq2SeqLM):
 
     Important Note:
         This model supports various sizes of the T5ForConditionalGeneration. For optimal performance, it is highly recommended to adjust the tensor parallelism setting
-        based on the model size. Please refer to the [Optimum RBLN Overview](../../../index.md) for guidance on choosing the appropriate tensor parallelism size for your model.
+        based on the model size. Please refer to the [Optimum RBLN Overview](https://docs.rbln.ai/software/optimum/optimum_rbln.html) for guidance on choosing the appropriate tensor parallelism size for your model.
 
 
     Examples:


### PR DESCRIPTION
## Summary
- `modeling_t5.py`: the two `[Optimum RBLN Overview](../../../index.md)` links in the tensor-parallel docstrings become `https://docs.rbln.ai/software/optimum/optimum_rbln.html`. The relative form only resolves inside the docs site, so `validate_docstrings.py` (which runs `mkdocs build --strict` in a throwaway project) fails on this file.
- `test-docstrings.yml`: remove the hardcoded exclusions for `modeling_t5.py` and `modeling_llava_next.py` (both from #196). `modeling_llava_next.py` parses cleanly today.

Follow-up: the Obedients docstring gate (#731) keeps `modeling_t5.py` excluded until this lands; that line goes in the next CI PR.

## Test plan
- [x] `validate_docstrings.py` passes locally on both files after the change
- [ ] GHA `test-docstrings` runs on `modeling_t5.py` in this PR (no longer excluded) and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)