### PR TITLE
other: ci - run the backward-compatibility suites on Obedients

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,0 +1,63 @@
+# Entry pipeline for the nightly build, uploaded by optimum-rbln-nightly-ci.
+# Replaces .github/workflows/rbln_scheduled_test.yaml.
+#
+# Everything runs at the full test level against every release's BC artifacts,
+# and the report at the end says what happened. Nothing is path-gated: the
+# uploads pass no --git-diff-base, so if_changed does not apply.
+
+env:
+  BC_BASE_PATH: "/mnt/shared_data/.cache/optimum-rbln/backward_compatibility"
+  UV_CACHE_DIR: "/mnt/uv_cache"
+  UV_LINK_MODE: "symlink"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+
+_upload: &upload
+  checkout:
+    sparse:
+      paths:
+        - .buildkite
+
+steps:
+  - label: ":mag: ruff"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    command:
+      - "uv sync --locked --python 3.12 --group quality --no-install-project"
+      - "uv run --no-sync ruff format --check ."
+      - "uv run --no-sync ruff check ."
+
+  # The PR gate only checks what a PR changed; the nightly checks every file.
+  - label: ":page_facing_up: docstrings"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    env:
+      DOCSTRINGS_ALL_FILES: "1"
+    command:
+      - "bash .buildkite/scripts/check-docstrings.sh"
+
+  # Sibling jobs: two uploads from one job make the second batch a barrier for
+  # the first.
+  - label: ":sparkles: upload pytest"
+    <<: *upload
+    command: |
+      export OPTIMUM_RBLN_TEST_LEVEL=full
+      export HF_USER_ID=Rebellions
+      buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
+
+  - label: ":sparkles: upload BC"
+    <<: *upload
+    command: |
+      bash .buildkite/scripts/bc-steps.sh --all | buildkite-agent pipeline upload
+
+  # continue_on_failure is a sibling of wait, not a value under it: nested, the
+  # flag is dropped and a failed suite takes the report down with it (build #1).
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":slack: report"
+    soft_fail: true
+    allow_dependency_failure: true
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    secrets:
+      OBEDIENTS_API_TOKEN: BUILDKITE_API_TOKEN
+      SLACK_BOT_TOKEN: SLACK_OAUTH_TOKEN
+    command:
+      - "python3 .buildkite/scripts/slack-report.py"

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -15,6 +15,10 @@ env:
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
   OPTIMUM_RBLN_TEST_LEVEL: "${OPTIMUM_RBLN_TEST_LEVEL:-default}"
+  # The hub tests push to a private repo under this namespace and skip themselves
+  # while it is unset (tests/test_base.py require_hf_user_id), which is how they
+  # stay out of an ordinary PR: only a full build's uploader exports it.
+  HF_USER_ID: "${HF_USER_ID:-}"
 
 # Run a suite only when the PR touches something that can change its result.
 # Honored because .buildkite/pr.yml uploads this file with --git-diff-base; the
@@ -94,6 +98,9 @@ _secrets: &secrets
   UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
+  # HF_TOKEN reads gated models; only this one may create a repo under
+  # Rebellions, which is what test_push_to_hub does.
+  HF_AUTH_TOKEN: MODEL_HUB_ACCESS
 
 _sync: &sync "bash .buildkite/scripts/sync.sh"
 

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -95,19 +95,7 @@ _secrets: &secrets
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
 
-# Pods share UV_CACHE_DIR, so a step often reuses an editable build another pod
-# made. That is what we want -- rebuilding it costs ~18s per step and the install
-# is editable, so the code always comes from this checkout -- but only the pod
-# that built it has the gitignored src/optimum/rbln/__version__.py the hatch-vcs
-# hook writes. The others write it here from the installed metadata; the code
-# reads nothing but __version__ from it.
-_sync: &sync |
-  echo '--- :package: uv sync'
-  uv sync --locked --python 3.12 --group tests
-  if [ ! -f src/optimum/rbln/__version__.py ]; then
-    uv run --no-sync python -c "import importlib.metadata as m, pathlib; pathlib.Path('src/optimum/rbln/__version__.py').write_text('__version__ = version = %r\n' % m.version('optimum-rbln'))"
-  fi
-  bash .buildkite/scripts/install-rebel-compiler.sh
+_sync: &sync "bash .buildkite/scripts/sync.sh"
 
 _npu: &npu
   npu:

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -56,6 +56,7 @@ steps:
       if [[ "$$BUILDKITE_MESSAGE" == *"[pytest-full]"* ]]; then
         echo "--- :mag: [pytest-full] in commit message"
         export OPTIMUM_RBLN_TEST_LEVEL=full
+        export HF_USER_ID=Rebellions
         buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
       else
         TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -1,9 +1,19 @@
 # Entry pipeline for PR builds. Gates run first; the pytest pipeline is uploaded
 # only after they pass, with --git-diff-base so if_changed in that pipeline works.
 env:
+  # Where every release's compiled artifacts live, written by the GHA bc_compile
+  # workflow on each tag. Same path as the GHA BC_BASE_PATH repository variable.
+  BC_BASE_PATH: "/mnt/shared_data/.cache/optimum-rbln/backward_compatibility"
   UV_CACHE_DIR: "/mnt/uv_cache"
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
+
+# Both upload jobs read only .buildkite; the suites they emit check out in full.
+_upload: &upload
+  checkout:
+    sparse:
+      paths:
+        - .buildkite
 
 steps:
   - label: ":closed_lock_with_key: team-member gate"
@@ -38,11 +48,10 @@ steps:
 
   # A [pytest-full] commit (the compiler-update bot's PRs) runs every suite at the
   # full level, so it uploads without --git-diff-base: nothing is path-gated away.
+  # Sibling jobs: two uploads from one job make the second batch a barrier for
+  # the first, so the pytest suites would wait on BC.
   - label: ":sparkles: upload pytest"
-    checkout:
-      sparse:
-        paths:
-          - .buildkite
+    <<: *upload
     command: |
       if [[ "$$BUILDKITE_MESSAGE" == *"[pytest-full]"* ]]; then
         echo "--- :mag: [pytest-full] in commit message"
@@ -53,3 +62,13 @@ steps:
         git fetch origin $$TARGET_BRANCH
         buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml --git-diff-base origin/$$TARGET_BRANCH
       fi
+
+  - label: ":sparkles: upload BC"
+    <<: *upload
+    command: |
+      if [[ "$$BUILDKITE_MESSAGE" != *"[pytest-full]"* ]]; then
+        TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}
+        git fetch origin $$TARGET_BRANCH
+        DIFF="--git-diff-base origin/$$TARGET_BRANCH"
+      fi
+      bash .buildkite/scripts/bc-steps.sh --latest | buildkite-agent pipeline upload $${DIFF:-}

--- a/.buildkite/scripts/bc-steps.sh
+++ b/.buildkite/scripts/bc-steps.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# bc-steps.sh {--latest|--all}
+#
+# Emits the backward-compatibility steps for `buildkite-agent pipeline upload`.
+# Each release under BC_BASE_PATH holds the artifacts that release compiled
+# (written by the GHA bc_compile workflow on every tag); a step reloads them with
+# the current code on a dummy device, so no NPU is involved -- only memory, which
+# is why the llm step asks for far more than the others.
+#
+# --latest is what a PR runs (the newest release only), --all is the nightly.
+set -euo pipefail
+
+mode="${1:?usage: bc-steps.sh --latest|--all}"
+: "${BC_BASE_PATH:?not set}"
+[ -d "$BC_BASE_PATH" ] || { echo "BC_BASE_PATH not found: $BC_BASE_PATH" >&2; exit 1; }
+
+# Directory names encode the tag with underscores (v0_11_2); sort -V on the
+# decoded form picks the newest release the same way the GHA workflow does.
+dirs=$(find "$BC_BASE_PATH" -maxdepth 1 -mindepth 1 -type d -not -name '.*' -printf '%f\n' | tr '_' '.' | sort -V)
+[ -n "$dirs" ] || { echo "no release directories under $BC_BASE_PATH" >&2; exit 1; }
+case "$mode" in
+  --latest) tags=$(printf '%s\n' "$dirs" | tail -1) ;;
+  --all)    tags="$dirs" ;;
+  *)        echo "unknown mode: $mode" >&2; exit 2 ;;
+esac
+
+cat <<'EOF'
+notify:
+  - github_commit_status:
+      context: "[OB] Optimum-RBLN BC"
+EOF
+echo "steps:"
+for tag in $tags; do
+  encoded="${tag//./_}"
+  for suite in transformers diffusers llm; do
+    if [ "$suite" = llm ]; then memory="128Gi"; else memory="32Gi"; fi
+    cat <<EOF
+  - label: ":rewind: BC $tag $suite"
+    key: "bc-${encoded}-${suite}"
+    if_changed:
+      include:
+        - ".buildkite/**"
+        - ".github/version.yaml"
+        - "pyproject.toml"
+        - "uv.lock"
+        - "src/**"
+        - "tests/__init__.py"
+        - "tests/test_base.py"
+        - "tests/test_${suite}.py"
+    image: "\${DEVTOOLS_DOCKER_IMAGE}"
+    resources:
+      cpu:
+        requests: "4"
+        limits: "4"
+      memory:
+        requests: "$memory"
+        limits: "$memory"
+    secrets:
+      UV_INDEX_REBELLIONS_USERNAME: REBEL_SW_DEV_USERNAME
+      UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
+      HF_TOKEN: HF_TOKEN
+      HF_HOME: HF_HOME
+    env:
+      OPTIMUM_RBLN_TEST_LEVEL: "full"
+      REUSE_ARTIFACTS_PATH: "$BC_BASE_PATH/$encoded"
+    timeout_in_minutes: 60
+    command:
+      - "bash .buildkite/scripts/sync.sh"
+      - "bash .buildkite/scripts/run-suite.sh $suite"
+EOF
+  done
+done

--- a/.buildkite/scripts/bc-steps.sh
+++ b/.buildkite/scripts/bc-steps.sh
@@ -4,8 +4,13 @@
 # Emits the backward-compatibility steps for `buildkite-agent pipeline upload`.
 # Each release under BC_BASE_PATH holds the artifacts that release compiled
 # (written by the GHA bc_compile workflow on every tag); a step reloads them with
-# the current code on a dummy device, so no NPU is involved -- only memory, which
-# is why the llm step asks for far more than the others.
+# the current code.
+#
+# The load uses a dummy device, but creating the runtime still dlopens
+# librbln-thunk.so, which only an NPU pod has (build #29 failed every model with
+# "Failed to load the RBLN Thunk library" on a CPU pod). GHA gets away with a
+# CPU pool because its runners carry the driver. The llm step also asks for far
+# more memory than the others, matching the 128GB runner it replaces.
 #
 # --latest is what a PR runs (the newest release only), --all is the nightly.
 set -euo pipefail
@@ -49,9 +54,9 @@ for tag in $tags; do
         - "tests/test_${suite}.py"
     image: "\${DEVTOOLS_DOCKER_IMAGE}"
     resources:
-      cpu:
-        requests: "4"
-        limits: "4"
+      npu:
+        count: 1
+        product: "RBLN-CA25"
       memory:
         requests: "$memory"
         limits: "$memory"

--- a/.buildkite/scripts/bc-steps.sh
+++ b/.buildkite/scripts/bc-steps.sh
@@ -6,11 +6,13 @@
 # (written by the GHA bc_compile workflow on every tag); a step reloads them with
 # the current code.
 #
-# The load uses a dummy device, but creating the runtime still dlopens
-# librbln-thunk.so, which only an NPU pod has (build #29 failed every model with
-# "Failed to load the RBLN Thunk library" on a CPU pod). GHA gets away with a
-# CPU pool because its runners carry the driver. The llm step also asks for far
-# more memory than the others, matching the 128GB runner it replaces.
+# The load uses a dummy device, so no NPU is involved -- but creating the runtime
+# still dlopens librbln-thunk.so, and a CPU pod has no UMD of its own (build #29
+# failed every model with "Failed to load the RBLN Thunk library"). The shared
+# UMD on LD_LIBRARY_PATH is what rebel_compiler's own no-device pytest step uses;
+# the extra entries are the other mounts it is published under, and a path that
+# does not exist is ignored. The llm step asks for far more memory than the
+# others, matching the 128GB runner it replaces.
 #
 # --latest is what a PR runs (the newest release only), --all is the nightly.
 set -euo pipefail
@@ -54,9 +56,9 @@ for tag in $tags; do
         - "tests/test_${suite}.py"
     image: "\${DEVTOOLS_DOCKER_IMAGE}"
     resources:
-      npu:
-        count: 1
-        product: "RBLN-CA25"
+      cpu:
+        requests: "4"
+        limits: "4"
       memory:
         requests: "$memory"
         limits: "$memory"
@@ -66,6 +68,7 @@ for tag in $tags; do
       HF_TOKEN: HF_TOKEN
       HF_HOME: HF_HOME
     env:
+      LD_LIBRARY_PATH: "/mnt/shared_data/cross-volume/umd:/mnt/shared_data/umd:/mnt/cross_data/umd"
       OPTIMUM_RBLN_TEST_LEVEL: "full"
       REUSE_ARTIFACTS_PATH: "$BC_BASE_PATH/$encoded"
     timeout_in_minutes: 60

--- a/.buildkite/scripts/run-suite.sh
+++ b/.buildkite/scripts/run-suite.sh
@@ -19,17 +19,29 @@ if [ -n "$tag" ] && [[ "${BUILDKITE_MESSAGE:-}" == *"$tag"* ]]; then
   exit 0
 fi
 
+# A backward-compatibility run loads an older release's artifacts on a dummy
+# device, so only test_generate applies and the suite is small enough not to split.
+bc=()
+if [ -n "${REUSE_ARTIFACTS_PATH:-}" ]; then
+  bc=(-k test_generate)
+  group=""
+fi
+
 echo "--- :pytest: ${suite}${group:+ (group ${group}/4)}"
 case "$suite" in
   config)
-    uv run --no-sync pytest -n 1 tests/test_config.py -vv --durations 0 ;;
+    uv run --no-sync pytest -n 1 tests/test_config.py -vv --durations 0 "${bc[@]}" ;;
   transformers)
-    uv run --no-sync pytest -n 1 tests/test_transformers.py -vv --durations 0 ;;
+    uv run --no-sync pytest -n 1 tests/test_transformers.py -vv --durations 0 "${bc[@]}" ;;
   diffusers)
-    uv run --no-sync pytest -n 1 tests/test_diffusers.py -vv --durations 0 ;;
+    uv run --no-sync pytest -n 1 tests/test_diffusers.py -vv --durations 0 "${bc[@]}" ;;
   llm)
-    [ -n "$group" ] || { echo "llm needs a group (1-4)" >&2; exit 2; }
-    uv run --no-sync pytest -n 1 tests/test_llm.py --splits 4 --group "$group" -vv --durations 0 ;;
+    if [ -n "$group" ]; then
+      uv run --no-sync pytest -n 1 tests/test_llm.py --splits 4 --group "$group" -vv --durations 0
+    else
+      [ ${#bc[@]} -gt 0 ] || { echo "llm needs a group (1-4)" >&2; exit 2; }
+      uv run --no-sync pytest -n 1 tests/test_llm.py -vv --durations 0 "${bc[@]}"
+    fi ;;
   cli-basic)
     uv run --no-sync .github/scripts/test_cli.py basic ;;
   cli-argument-parsing)

--- a/.buildkite/scripts/slack-report.py
+++ b/.buildkite/scripts/slack-report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Post this build's suite results to Slack.
+
+Replaces .github/workflows/slack_report.yaml: the job states come from the
+Obedients REST API rather than the GitHub Actions one, and the versions are read
+from the checkout instead of being passed in as workflow inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+API = "https://obedients-api.k8s.rebellions.in/v2/organizations"
+
+
+def api_get(path: str, token: str) -> dict:
+    req = urllib.request.Request(f"{API}/{path}", headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode())
+
+
+def pinned_version(path: str, pattern: str) -> str:
+    try:
+        match = re.search(pattern, Path(path).read_text())
+    except OSError:
+        return "unknown"
+    return match.group(1) if match else "unknown"
+
+
+def summarize(jobs: list[dict], prefix: str) -> tuple[str, int, int]:
+    """A one-line verdict for the jobs whose label starts with prefix."""
+    picked = [j for j in jobs if (j.get("label") or "").startswith(prefix)]
+    if not picked:
+        return "⏭️ Not run", 0, 0
+    failed = [j for j in picked if j.get("state") in ("failed", "broken", "canceled")]
+    ran = [j for j in picked if j.get("state") != "skipped"]
+    if not ran:
+        return "⏭️ Skipped", 0, 0
+    if failed:
+        names = ", ".join(sorted((j["label"].split(": ", 1)[-1]) for j in failed))
+        return f"❌ {len(failed)}/{len(ran)} failed - `{names}`", len(failed), len(ran)
+    return f"✅ {len(ran)}/{len(ran)} passed", 0, len(ran)
+
+
+def main() -> int:
+    token = os.environ.get("OBEDIENTS_API_TOKEN")
+    slack_token = os.environ.get("SLACK_BOT_TOKEN")
+    # A scheduled run is the real nightly; anything else is someone trying it out.
+    scheduled = os.environ.get("BUILDKITE_SOURCE") == "schedule"
+    channel = os.environ.get("SLACK_CI_REPORTER_CHANNEL" if scheduled else "SLACK_CI_PLAYGROUND_CHANNEL")
+    if not (token and slack_token and channel):
+        print("OBEDIENTS_API_TOKEN, SLACK_BOT_TOKEN or the channel is unset", file=sys.stderr)
+        return 1
+
+    org = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
+    pipeline = os.environ["BUILDKITE_PIPELINE_SLUG"]
+    number = os.environ["BUILDKITE_BUILD_NUMBER"]
+    build = api_get(f"{org}/pipelines/{pipeline}/builds/{number}", token)
+
+    # This step is still running, and its own state would always read as such.
+    me = os.environ.get("BUILDKITE_JOB_ID")
+    jobs = [j for j in build.get("jobs", []) if j.get("id") != me]
+
+    pytest_status, pytest_failed, _ = summarize(jobs, ":pytest:")
+    bc_status, bc_failed, _ = summarize(jobs, ":rewind:")
+    gates = [j for j in jobs if (j.get("label") or "").startswith((":mag:", ":page_facing_up:"))]
+    gates_failed = [j for j in gates if j.get("state") in ("failed", "broken")]
+
+    title_base = os.environ.get("SLACK_TITLE", "Optimum-RBLN Nightly")
+    if gates_failed:
+        title = f"❌ {title_base} - code quality"
+    elif pytest_failed:
+        title = f"❌ {title_base}"
+    elif bc_failed:
+        title = f"❌ {title_base} - BC"
+    else:
+        title = f"✅ {title_base}"
+
+    commit = build.get("commit", "")[:8]
+    repo = os.environ.get("BUILDKITE_REPO", "").removesuffix(".git").split("github.com")[-1].lstrip(":/")
+    fields = [
+        ("*Commit*", f"<https://github.com/{repo}/commit/{commit}|{commit}>"),
+        ("*Build*", f"<{build.get('web_url', '')}|View Details>"),
+        ("*Compiler*", "`" + pinned_version(".github/version.yaml", r"rebel_compiler_version:\s*(\S+)") + "`"),
+        ("*Transformers*", "`" + pinned_version("pyproject.toml", r'"transformers[<>=]{2}([^",]+)') + "`"),
+        ("*Diffusers*", "`" + pinned_version("pyproject.toml", r'"diffusers[<>=]{2}([^",]+)') + "`"),
+    ]
+    blocks = [{"type": "header", "text": {"type": "plain_text", "text": title}}]
+    blocks += [
+        {"type": "section", "fields": [{"type": "mrkdwn", "text": k}, {"type": "mrkdwn", "text": v}]}
+        for k, v in fields
+    ]
+    blocks += [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "fields": [{"type": "mrkdwn", "text": "*Pytest*"}, {"type": "mrkdwn", "text": pytest_status}],
+        },
+        {"type": "section", "fields": [{"type": "mrkdwn", "text": "*BC*"}, {"type": "mrkdwn", "text": bc_status}]},
+    ]
+
+    print(f"{title}\n  pytest: {pytest_status}\n  BC: {bc_status}")
+    payload = json.dumps({"channel": channel, "text": title, "blocks": blocks}).encode()
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {slack_token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = json.loads(resp.read().decode())
+    # Slack answers 200 even when it refuses the message.
+    if not body.get("ok"):
+        print(f"Slack refused the message: {body.get('error')}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.buildkite/scripts/sync.sh
+++ b/.buildkite/scripts/sync.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# uv sync + rebel-compiler, shared by the pytest suites and the BC steps.
+#
+# Pods share UV_CACHE_DIR, so a step often reuses an editable build another pod
+# made. That is what we want -- rebuilding it costs ~18s per step and the install
+# is editable, so the code always comes from this checkout -- but only the pod
+# that built it has the gitignored src/optimum/rbln/__version__.py the hatch-vcs
+# hook writes. The others write it here from the installed metadata; the code
+# reads nothing but __version__ from it.
+set -euo pipefail
+
+echo '--- :package: uv sync'
+uv sync --locked --python 3.12 --group tests
+if [ ! -f src/optimum/rbln/__version__.py ]; then
+  uv run --no-sync python -c "import importlib.metadata as m, pathlib; pathlib.Path('src/optimum/rbln/__version__.py').write_text('__version__ = version = %r\n' % m.version('optimum-rbln'))"
+fi
+bash .buildkite/scripts/install-rebel-compiler.sh


### PR DESCRIPTION
## Summary
Phase 3b. Stacked on #737 — GitHub retargets this to `dev` when that merges.

- `.buildkite/scripts/bc-steps.sh {--latest|--all}` emits the BC steps for `buildkite-agent pipeline upload`. Releases are read from `BC_BASE_PATH` at upload time, so the list is never checked in. `--latest` is the PR's scope (what `bc_inference.yaml` does today), `--all` is the nightly's (`bc_full_inference.yaml`). Directory names encode the tag with underscores, and `sort -V` on the decoded form picks the newest release.
- `.buildkite/pr.yml` uploads `--latest` alongside the pytest pipeline, path-gated the same way, reported as `[OB] Optimum-RBLN BC`.
- `.buildkite/scripts/run-suite.sh` learns the reuse mode: with `REUSE_ARTIFACTS_PATH` set it adds `-k test_generate` and stops splitting `llm`, matching `rbln_optimum_pytest.yaml`'s BC branch.
- `.buildkite/scripts/sync.sh` holds the uv sync recipe that both the pytest pipeline and the generated steps run, so they cannot drift.

**These steps take no NPU.** With `REUSE_ARTIFACTS_PATH` set, `tests/test_base.py` loads the model under `ContextRblnConfig(device=DUMMY_DEVICE_CODE)` and `test_generate` skips its output comparison — the check is that current code can still load and run an older release's artifacts. GHA runs them on the CPU-only `rbln-sw-k8s-4c-128gb` / `-32gb` pools for the same reason. So a PR now gets 3 more steps but no more NPU contention.

## Risk
`BC_BASE_PATH` (`/mnt/shared_data/.cache/optimum-rbln/backward_compatibility`) must be visible from Obedients pods. `/mnt/shared_data` is mounted on this cluster's agents, but this PR's own build is the first to read that subtree — if it is not there, the upload step fails loudly rather than silently skipping BC.

## Test plan
- [ ] The upload step lists releases and emits 3 steps for the newest
- [ ] The three BC steps pass on CPU-only pods
- [ ] `[OB] Optimum-RBLN BC` appears on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)