### PR TITLE
other: ci - run the nightly on Obedients and report it to Slack

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -39,7 +39,6 @@ steps:
     <<: *upload
     command: |
       export OPTIMUM_RBLN_TEST_LEVEL=full
-      export HF_USER_ID=Rebellions
       buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
 
   - label: ":sparkles: upload BC"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,0 +1,61 @@
+# Entry pipeline for the nightly build, uploaded by optimum-rbln-nightly-ci.
+# Replaces .github/workflows/rbln_scheduled_test.yaml.
+#
+# Everything runs at the full test level against every release's BC artifacts,
+# and the report at the end says what happened. Nothing is path-gated: the
+# uploads pass no --git-diff-base, so if_changed does not apply.
+
+env:
+  BC_BASE_PATH: "/mnt/shared_data/.cache/optimum-rbln/backward_compatibility"
+  UV_CACHE_DIR: "/mnt/uv_cache"
+  UV_LINK_MODE: "symlink"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+
+_upload: &upload
+  checkout:
+    sparse:
+      paths:
+        - .buildkite
+
+steps:
+  - label: ":mag: ruff"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    command:
+      - "uv sync --locked --python 3.12 --group quality --no-install-project"
+      - "uv run --no-sync ruff format --check ."
+      - "uv run --no-sync ruff check ."
+
+  # The PR gate only checks what a PR changed; the nightly checks every file.
+  - label: ":page_facing_up: docstrings"
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    env:
+      DOCSTRINGS_ALL_FILES: "1"
+    command:
+      - "bash .buildkite/scripts/check-docstrings.sh"
+
+  # Sibling jobs: two uploads from one job make the second batch a barrier for
+  # the first.
+  - label: ":sparkles: upload pytest"
+    <<: *upload
+    command: |
+      export OPTIMUM_RBLN_TEST_LEVEL=full
+      export HF_USER_ID=Rebellions
+      buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
+
+  - label: ":sparkles: upload BC"
+    <<: *upload
+    command: |
+      bash .buildkite/scripts/bc-steps.sh --all | buildkite-agent pipeline upload
+
+  # continue_on_failure so a failed suite still gets reported.
+  - wait:
+      continue_on_failure: true
+
+  - label: ":slack: report"
+    soft_fail: true
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    secrets:
+      OBEDIENTS_API_TOKEN: BUILDKITE_API_TOKEN
+      SLACK_BOT_TOKEN: SLACK_OAUTH_TOKEN
+    command:
+      - "python3 .buildkite/scripts/slack-report.py"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -39,6 +39,7 @@ steps:
     <<: *upload
     command: |
       export OPTIMUM_RBLN_TEST_LEVEL=full
+      export HF_USER_ID=Rebellions
       buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
 
   - label: ":sparkles: upload BC"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -46,12 +46,14 @@ steps:
     command: |
       bash .buildkite/scripts/bc-steps.sh --all | buildkite-agent pipeline upload
 
-  # continue_on_failure so a failed suite still gets reported.
-  - wait:
-      continue_on_failure: true
+  # continue_on_failure is a sibling of wait, not a value under it: nested, the
+  # flag is dropped and a failed suite takes the report down with it (build #1).
+  - wait: ~
+    continue_on_failure: true
 
   - label: ":slack: report"
     soft_fail: true
+    allow_dependency_failure: true
     image: "${DEVTOOLS_DOCKER_IMAGE}"
     secrets:
       OBEDIENTS_API_TOKEN: BUILDKITE_API_TOKEN

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -15,10 +15,11 @@ env:
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
   OPTIMUM_RBLN_TEST_LEVEL: "${OPTIMUM_RBLN_TEST_LEVEL:-default}"
-  # The hub tests push to a private repo under this namespace and skip when it is
-  # empty (tests/test_base.py require_hf_user_id), which is how they stay out of
-  # an ordinary PR: only a full build's uploader exports it.
-  HF_USER_ID: "${HF_USER_ID:-}"
+  # The hub tests (tests/test_base.py BaseHubTest) stay off until the vault has a
+  # token that may write under the Rebellions namespace: HF_TOKEN is read-only
+  # there, so enabling them returned 403 in nightly build #1. Once such a secret
+  # exists, map it to HF_AUTH_TOKEN below and export HF_USER_ID=Rebellions from
+  # the full-build uploaders; the tests skip themselves while HF_USER_ID is unset.
 
 # Run a suite only when the PR touches something that can change its result.
 # Honored because .buildkite/pr.yml uploads this file with --git-diff-base; the
@@ -98,7 +99,6 @@ _secrets: &secrets
   UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
-  HF_AUTH_TOKEN: HF_TOKEN
 
 _sync: &sync "bash .buildkite/scripts/sync.sh"
 

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -15,11 +15,10 @@ env:
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
   OPTIMUM_RBLN_TEST_LEVEL: "${OPTIMUM_RBLN_TEST_LEVEL:-default}"
-  # The hub tests (tests/test_base.py BaseHubTest) stay off until the vault has a
-  # token that may write under the Rebellions namespace: HF_TOKEN is read-only
-  # there, so enabling them returned 403 in nightly build #1. Once such a secret
-  # exists, map it to HF_AUTH_TOKEN below and export HF_USER_ID=Rebellions from
-  # the full-build uploaders; the tests skip themselves while HF_USER_ID is unset.
+  # The hub tests push to a private repo under this namespace and skip themselves
+  # while it is unset (tests/test_base.py require_hf_user_id), which is how they
+  # stay out of an ordinary PR: only a full build's uploader exports it.
+  HF_USER_ID: "${HF_USER_ID:-}"
 
 # Run a suite only when the PR touches something that can change its result.
 # Honored because .buildkite/pr.yml uploads this file with --git-diff-base; the
@@ -99,6 +98,9 @@ _secrets: &secrets
   UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
+  # HF_TOKEN reads gated models; only this one may create a repo under
+  # Rebellions, which is what test_push_to_hub does.
+  HF_AUTH_TOKEN: MODEL_HUB_ACCESS
 
 _sync: &sync "bash .buildkite/scripts/sync.sh"
 

--- a/.buildkite/pipelines/pytest/pipeline.yml
+++ b/.buildkite/pipelines/pytest/pipeline.yml
@@ -15,6 +15,10 @@ env:
   UV_LINK_MODE: "symlink"
   UV_INDEX_STRATEGY: "unsafe-best-match"
   OPTIMUM_RBLN_TEST_LEVEL: "${OPTIMUM_RBLN_TEST_LEVEL:-default}"
+  # The hub tests push to a private repo under this namespace and skip when it is
+  # empty (tests/test_base.py require_hf_user_id), which is how they stay out of
+  # an ordinary PR: only a full build's uploader exports it.
+  HF_USER_ID: "${HF_USER_ID:-}"
 
 # Run a suite only when the PR touches something that can change its result.
 # Honored because .buildkite/pr.yml uploads this file with --git-diff-base; the
@@ -94,6 +98,7 @@ _secrets: &secrets
   UV_INDEX_REBELLIONS_PASSWORD: REBEL_SW_DEV_PASSWORD
   HF_TOKEN: HF_TOKEN
   HF_HOME: HF_HOME
+  HF_AUTH_TOKEN: HF_TOKEN
 
 _sync: &sync "bash .buildkite/scripts/sync.sh"
 

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -56,6 +56,7 @@ steps:
       if [[ "$$BUILDKITE_MESSAGE" == *"[pytest-full]"* ]]; then
         echo "--- :mag: [pytest-full] in commit message"
         export OPTIMUM_RBLN_TEST_LEVEL=full
+        export HF_USER_ID=Rebellions
         buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
       else
         TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}

--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -56,7 +56,6 @@ steps:
       if [[ "$$BUILDKITE_MESSAGE" == *"[pytest-full]"* ]]; then
         echo "--- :mag: [pytest-full] in commit message"
         export OPTIMUM_RBLN_TEST_LEVEL=full
-        export HF_USER_ID=Rebellions
         buildkite-agent pipeline upload .buildkite/pipelines/pytest/pipeline.yml
       else
         TARGET_BRANCH=$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}

--- a/.buildkite/scripts/slack-report.py
+++ b/.buildkite/scripts/slack-report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Post this build's suite results to Slack.
+
+Replaces .github/workflows/slack_report.yaml: the job states come from the
+Obedients REST API rather than the GitHub Actions one, and the versions are read
+from the checkout instead of being passed in as workflow inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+API = "https://obedients-api.k8s.rebellions.in/v2/organizations"
+
+
+def api_get(path: str, token: str) -> dict:
+    req = urllib.request.Request(f"{API}/{path}", headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode())
+
+
+def pinned_version(path: str, pattern: str) -> str:
+    try:
+        match = re.search(pattern, Path(path).read_text())
+    except OSError:
+        return "unknown"
+    return match.group(1) if match else "unknown"
+
+
+def summarize(jobs: list[dict], prefix: str) -> tuple[str, int, int]:
+    """A one-line verdict for the jobs whose label starts with prefix."""
+    picked = [j for j in jobs if (j.get("label") or "").startswith(prefix)]
+    if not picked:
+        return "⏭️ Not run", 0, 0
+    failed = [j for j in picked if j.get("state") in ("failed", "broken", "canceled")]
+    ran = [j for j in picked if j.get("state") != "skipped"]
+    if not ran:
+        return "⏭️ Skipped", 0, 0
+    if failed:
+        names = ", ".join(sorted((j["label"].split(": ", 1)[-1]) for j in failed))
+        return f"❌ {len(failed)}/{len(ran)} failed - `{names}`", len(failed), len(ran)
+    return f"✅ {len(ran)}/{len(ran)} passed", 0, len(ran)
+
+
+def main() -> int:
+    token = os.environ.get("OBEDIENTS_API_TOKEN")
+    slack_token = os.environ.get("SLACK_BOT_TOKEN")
+    # A scheduled run is the real nightly; anything else is someone trying it out.
+    scheduled = os.environ.get("BUILDKITE_SOURCE") == "schedule"
+    channel = os.environ.get("SLACK_CI_REPORTER_CHANNEL" if scheduled else "SLACK_CI_PLAYGROUND_CHANNEL")
+    if not (token and slack_token and channel):
+        print("OBEDIENTS_API_TOKEN, SLACK_BOT_TOKEN or the channel is unset", file=sys.stderr)
+        return 1
+
+    org = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
+    pipeline = os.environ["BUILDKITE_PIPELINE_SLUG"]
+    number = os.environ["BUILDKITE_BUILD_NUMBER"]
+    build = api_get(f"{org}/pipelines/{pipeline}/builds/{number}", token)
+
+    # This step is still running, and its own state would always read as such.
+    me = os.environ.get("BUILDKITE_JOB_ID")
+    jobs = [j for j in build.get("jobs", []) if j.get("id") != me]
+
+    pytest_status, pytest_failed, _ = summarize(jobs, ":pytest:")
+    bc_status, bc_failed, _ = summarize(jobs, ":rewind:")
+    gates = [j for j in jobs if (j.get("label") or "").startswith((":mag:", ":page_facing_up:"))]
+    gates_failed = [j for j in gates if j.get("state") in ("failed", "broken")]
+
+    title_base = os.environ.get("SLACK_TITLE", "Optimum-RBLN Nightly")
+    if gates_failed:
+        title = f"❌ {title_base} - code quality"
+    elif pytest_failed:
+        title = f"❌ {title_base}"
+    elif bc_failed:
+        title = f"❌ {title_base} - BC"
+    else:
+        title = f"✅ {title_base}"
+
+    commit = build.get("commit", "")[:8]
+    repo = os.environ.get("BUILDKITE_REPO", "").removesuffix(".git").split("github.com")[-1].lstrip(":/")
+    fields = [
+        ("*Commit*", f"<https://github.com/{repo}/commit/{commit}|{commit}>"),
+        ("*Build*", f"<{build.get('web_url', '')}|View Details>"),
+        ("*Compiler*", "`" + pinned_version(".github/version.yaml", r"rebel_compiler_version:\s*(\S+)") + "`"),
+        ("*Transformers*", "`" + pinned_version("pyproject.toml", r'"transformers[<>=]{2}([^",]+)') + "`"),
+        ("*Diffusers*", "`" + pinned_version("pyproject.toml", r'"diffusers[<>=]{2}([^",]+)') + "`"),
+    ]
+    blocks = [{"type": "header", "text": {"type": "plain_text", "text": title}}]
+    blocks += [
+        {"type": "section", "fields": [{"type": "mrkdwn", "text": k}, {"type": "mrkdwn", "text": v}]}
+        for k, v in fields
+    ]
+    blocks += [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "fields": [{"type": "mrkdwn", "text": "*Pytest*"}, {"type": "mrkdwn", "text": pytest_status}],
+        },
+        {"type": "section", "fields": [{"type": "mrkdwn", "text": "*BC*"}, {"type": "mrkdwn", "text": bc_status}]},
+    ]
+
+    print(f"{title}\n  pytest: {pytest_status}\n  BC: {bc_status}")
+    payload = json.dumps({"channel": channel, "text": title, "blocks": blocks}).encode()
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {slack_token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = json.loads(resp.read().decode())
+    # Slack answers 200 even when it refuses the message.
+    if not body.get("ok"):
+        print(f"Slack refused the message: {body.get('error')}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Phase 3c, stacked on #738 (which is stacked on #737). Replaces `.github/workflows/rbln_scheduled_test.yaml`.

- `.buildkite/nightly.yml`: ruff, docstrings over **every** file (`DOCSTRINGS_ALL_FILES=1`, where the PR gate only checks the diff), the pytest pipeline at the full level, and the BC steps for **every** release (`bc-steps.sh --all`). Nothing is path-gated — the uploads pass no `--git-diff-base`.
- `.buildkite/scripts/slack-report.py`: reads this build's job states from the Obedients REST API and posts the summary `slack_report.yaml` used to — commit, pinned compiler, transformers and diffusers versions, and a verdict per suite group. A scheduled build goes to the reporter channel, anything else to the playground channel, matching the GHA `use_playground_channel` input. The step is `soft_fail`: a report that cannot be delivered should not turn a green nightly red.
- Hub tests come on for full builds: `HF_USER_ID=Rebellions` from the uploader, and `HF_AUTH_TOKEN` mapped to the vault's new `MODEL_HUB_ACCESS`. `HF_TOKEN` reads gated models but cannot create a repo under that namespace, which is what `test_push_to_hub` does — build #1 returned 403 with it. An ordinary PR leaves `HF_USER_ID` unset, so the tests keep skipping there.

## Needs a pipeline
`optimum-rbln-nightly-ci` does not exist yet. Settings are in the working doc (section 4): same cluster, `dev` as the default branch, PR and branch builds **off**, initial step `buildkite-agent pipeline upload .buildkite/nightly.yml`, schedule `0 16 * * *`.

## Not in this PR
Deleting the GHA nightly and BC workflows. That waits until this has run green a few times.

## Test plan
- [x] The pipeline uploads 19 steps: 2 gates, 10 pytest at the full level (the advanced CLI suites included), 9 BC across 3 releases, then the report ([build #1](https://obedients.k8s.rebellions.in/orgs/main/pipelines/optimum-rbln-nightly-ci/builds/1))
- [ ] A manual build posts to the playground channel
- [ ] Every suite runs at the full level, and the advanced CLI suites appear
- [ ] BC steps appear for every release under `BC_BASE_PATH`, not just the newest
- [ ] `test_push_to_hub` runs instead of skipping, now that `MODEL_HUB_ACCESS` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

