### PR TITLE
other: ci - restore the PR Slack report the Obedients migration dropped

### DIFF
--- a/.buildkite/pr.yml
+++ b/.buildkite/pr.yml
@@ -73,3 +73,25 @@ steps:
         DIFF="--git-diff-base origin/$$TARGET_BRANCH"
       fi
       bash .buildkite/scripts/bc-steps.sh --latest | buildkite-agent pipeline upload $${DIFF:-}
+
+  # continue_on_failure is a sibling of wait, not a value under it: nested, the
+  # flag is dropped and a failed suite takes the report down with it.
+  - wait: ~
+    continue_on_failure: true
+
+  # The compiler-update bot and renovate commit as "[pytest-full] [slack-report]
+  # dependency: ...", and the GHA PR workflow reported those runs to the
+  # playground channel. slack-report.py picks that channel itself for anything
+  # that is not a scheduled build.
+  - label: ":slack: report"
+    if: build.message =~ /\[slack-report\]/
+    soft_fail: true
+    allow_dependency_failure: true
+    image: "${DEVTOOLS_DOCKER_IMAGE}"
+    env:
+      SLACK_TITLE: "Optimum-RBLN PR Full Test Results"
+    secrets:
+      OBEDIENTS_API_TOKEN: BUILDKITE_API_TOKEN
+      SLACK_BOT_TOKEN: SLACK_OAUTH_TOKEN
+    command:
+      - "python3 .buildkite/scripts/slack-report.py"


### PR DESCRIPTION
## Why

`.github/workflows/rbln_trigger_on_pr.yaml` had a `check-slack-report` job: when the head commit message contained `[slack-report]`, it called `slack_report.yaml` with `use_playground_channel: true` and the title `Optimum-RBLN PR Full Test Results`.

Both `auto_compiler_update.yaml:119` and `.github/renovate.json:11` write their commit message as `"[pytest-full] [slack-report] dependency: Update dependency ..."`. #737 deleted those workflows, but `.buildkite/pr.yml` only handles `[pytest-full]` — so the dependency-bump PRs (e.g. #697) silently stopped reporting to Slack.

## What

Adds the missing half to `.buildkite/pr.yml`:

- a trailing `wait` with `continue_on_failure: true` as a sibling key, so a failed suite does not take the report down with it;
- a `:slack: report` step gated on `build.message =~ /\[slack-report\]/`, `soft_fail` + `allow_dependency_failure`, with `SLACK_TITLE: "Optimum-RBLN PR Full Test Results"`.

No change to `slack-report.py`: it already reads `SLACK_TITLE`, and it already posts to `SLACK_CI_PLAYGROUND_CHANNEL` for anything whose `BUILDKITE_SOURCE` is not `schedule` — which is exactly the GHA behaviour for PR runs.

## Validation

This branch's own commit message carries `[slack-report]`, so its PR build runs the new step and posts to the playground channel. It deliberately does **not** carry `[pytest-full]`, so the suites still run at the default level and the report just says so. **Drop the directive from the squash message when merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)